### PR TITLE
Easy timers

### DIFF
--- a/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -10,7 +11,7 @@ namespace JustEat.StatsD.Tests.Extensions
         [Test]
         public void CanRecordStat()
         {
-            var publisher = new FakePublisher();
+            var publisher = new FakeStatsPublisher();
 
             using (publisher.StartTimer("stat"))
             {
@@ -19,12 +20,13 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
         }
 
         [Test]
         public void CanRecordTwoStats()
         {
-            var publisher = new FakePublisher();
+            var publisher = new FakeStatsPublisher();
 
             using (publisher.StartTimer("stat1"))
             {
@@ -38,12 +40,13 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(2));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat1", "stat2"}));
         }
 
         [Test]
         public async Task CanRecordStatAsync()
         {
-            var publisher = new FakePublisher();
+            var publisher = new FakeStatsPublisher();
 
             using (publisher.StartTimer("stat"))
             {
@@ -52,12 +55,13 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
         }
 
         [Test]
         public async Task CanRecordTwoStatsAsync()
         {
-            var publisher = new FakePublisher();
+            var publisher = new FakeStatsPublisher();
 
             using (publisher.StartTimer("stat1"))
             {
@@ -71,48 +75,53 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(2));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat1", "stat2" }));
         }
 
         [Test]
         public void CanRecordStatInAction()
         {
-            var publisher = new FakePublisher();
+            var publisher = new FakeStatsPublisher();
             publisher.Time("stat", () => Delay());
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
         }
 
         [Test]
         public void CanRecordStatInFunction()
         {
-            var publisher = new FakePublisher();
+            var publisher = new FakeStatsPublisher();
             var answer = publisher.Time("stat", () => DelayedAnswer());
 
             Assert.That(answer, Is.EqualTo(42));
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
         }
 
         [Test]
         public async Task CanRecordStatInAsyncAction()
         {
-            var publisher = new FakePublisher();
+            var publisher = new FakeStatsPublisher();
             await publisher.Time("stat", async () => await DelayAsync());
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
         }
 
         [Test]
         public async Task CanRecordStatInAsyncFunction()
         {
-            var publisher = new FakePublisher();
+            var publisher = new FakeStatsPublisher();
             var answer = await publisher.Time("stat", async () => await DelayedAnswerAsync());
 
             Assert.That(answer, Is.EqualTo(42));
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
         }
 
         private void Delay()

--- a/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
@@ -1,0 +1,89 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace JustEat.StatsD.Tests.Extensions
+{
+    [TestFixture]
+    public class ExtensionsTests
+    {
+        [Test]
+        public void CanRecordStat()
+        {
+            var publisher = new FakePublisher();
+
+            using (publisher.StartTimer("stat"))
+            {
+                Delay();
+            }
+
+            Assert.That(publisher.CallCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CanRecordTwoStats()
+        {
+            var publisher = new FakePublisher();
+
+            using (publisher.StartTimer("stat1"))
+            {
+                Delay();
+            }
+
+            using (publisher.StartTimer("stat2"))
+            {
+                Delay();
+            }
+
+            Assert.That(publisher.CallCount, Is.EqualTo(2));
+        }
+
+        [Test]
+        public async Task CanRecordStatAsync()
+        {
+            var publisher = new FakePublisher();
+
+            using (publisher.StartTimer("stat"))
+            {
+                await DelayAsync();
+            }
+
+            Assert.That(publisher.CallCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CanRecordStatInAction()
+        {
+            var publisher = new FakePublisher();
+            publisher.Time("stat", () => Delay());
+
+            Assert.That(publisher.CallCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CanRecordStatInFunction()
+        {
+            var publisher = new FakePublisher();
+            var answer = publisher.Time("stat", () => DelayedAnswer());
+
+            Assert.That(answer, Is.EqualTo(42));
+            Assert.That(publisher.CallCount, Is.EqualTo(1));
+        }
+
+        private void Delay()
+        {
+            Thread.Sleep(100);
+        }
+
+        private int DelayedAnswer()
+        {
+            Thread.Sleep(100);
+            return 42;
+        }
+
+        private async Task DelayAsync()
+        {
+            await Task.Delay(100);
+        }
+    }
+}

--- a/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
@@ -10,7 +10,6 @@ namespace JustEat.StatsD.Tests.Extensions
     public class ExtensionsTests
     {
         private const int StandardDelayMillis = 200;
-        private readonly TimeSpan _standardDelay =  TimeSpan.FromMilliseconds(StandardDelayMillis);
 
         [Test]
         public void CanRecordStat()
@@ -24,8 +23,9 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.LastDuration, Is.GreaterThanOrEqualTo(_standardDelay));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
+
+            AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
 
         [Test]
@@ -45,8 +45,8 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(2));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.LastDuration, Is.GreaterThanOrEqualTo(_standardDelay));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat1", "stat2" }));
+            AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
 
         [Test]
@@ -61,8 +61,8 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.LastDuration, Is.GreaterThanOrEqualTo(_standardDelay));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
+            AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
 
         [Test]
@@ -82,8 +82,8 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(2));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.LastDuration, Is.GreaterThanOrEqualTo(_standardDelay));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat1", "stat2" }));
+            AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
 
         [Test]
@@ -94,8 +94,8 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.LastDuration, Is.GreaterThanOrEqualTo(_standardDelay));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
+            AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
 
         [Test]
@@ -107,8 +107,8 @@ namespace JustEat.StatsD.Tests.Extensions
             Assert.That(answer, Is.EqualTo(42));
             Assert.That(publisher.CallCount, Is.EqualTo(1));
             Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.LastDuration, Is.GreaterThanOrEqualTo(_standardDelay));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
+            AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace JustEat.StatsD.Tests.Extensions
             var publisher = new FakeStatsPublisher();
             await publisher.Time("stat", async () => await DelayAsync());
 
-            Assert.That(publisher.LastDuration, Is.GreaterThanOrEqualTo(_standardDelay));
+            AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace JustEat.StatsD.Tests.Extensions
             var publisher = new FakeStatsPublisher();
             await publisher.Time("stat", async () => await DelayedAnswerAsync());
 
-            Assert.That(publisher.LastDuration, Is.GreaterThanOrEqualTo(_standardDelay));
+            AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
 
         private void Delay()
@@ -172,6 +172,16 @@ namespace JustEat.StatsD.Tests.Extensions
         {
             await Task.Delay(StandardDelayMillis);
             return 42;
+        }
+
+        private void AssertDurationIsInExpectedRange(TimeSpan duration)
+        {
+            var expectedDelayLower = TimeSpan.FromMilliseconds(StandardDelayMillis);
+            var expectedDelayUpper = TimeSpan.FromMilliseconds(StandardDelayMillis * 2);
+
+            Assert.That(duration, Is.GreaterThanOrEqualTo(expectedDelayLower));
+            Assert.That(duration, Is.LessThanOrEqualTo(expectedDelayUpper));
+
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/Extensions/FakePublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakePublisher.cs
@@ -5,9 +5,11 @@ namespace JustEat.StatsD.Tests.Extensions
     class FakePublisher : IStatsDPublisher
     {
         public int CallCount { get; set; }
+        public int DisposeCount { get; set; }
 
         public void Dispose()
         {
+            DisposeCount++;
         }
 
         public void Increment(string bucket)

--- a/src/JustEat.StatsD.Tests/Extensions/FakePublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakePublisher.cs
@@ -1,0 +1,78 @@
+﻿using System;
+
+namespace JustEat.StatsD.Tests.Extensions
+{
+    class FakePublisher : IStatsDPublisher
+    {
+        public int CallCount { get; set; }
+
+        public void Dispose()
+        {
+        }
+
+        public void Increment(string bucket)
+        {
+            CallCount++;
+        }
+
+        public void Increment(long value, string bucket)
+        {
+            CallCount++;
+        }
+
+        public void Increment(long value, double sampleRate, string bucket)
+        {
+            CallCount++;
+        }
+
+        public void Increment(long value, double sampleRate, params string[] buckets)
+        {
+            CallCount++;
+        }
+
+        public void Decrement(string bucket)
+        {
+            CallCount++;
+        }
+
+        public void Decrement(long value, string bucket)
+        {
+            CallCount++;
+        }
+
+        public void Decrement(long value, double sampleRate, string bucket)
+        {
+            CallCount++;
+        }
+
+        public void Decrement(long value, double sampleRate, params string[] buckets)
+        {
+            CallCount++;
+        }
+
+        public void Gauge(long value, string bucket)
+        {
+            CallCount++;
+        }
+
+        public void Gauge(long value, string bucket, DateTime timestamp)
+        {
+            CallCount++;
+        }
+
+        public void Timing(TimeSpan duration, string bucket)
+        {
+            CallCount++;
+        }
+
+        public void Timing(TimeSpan duration, double sampleRate, string bucket)
+        {
+            CallCount++;
+        }
+
+        public void MarkEvent(string name)
+        {
+            CallCount++;
+        }
+    }
+}

--- a/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -7,6 +7,8 @@ namespace JustEat.StatsD.Tests.Extensions
     {
         public int CallCount { get; set; }
         public int DisposeCount { get; set; }
+        public TimeSpan LastDuration { get; set; }
+
         public List<string> BucketNames { get; private set; }
 
         public FakeStatsPublisher()
@@ -82,12 +84,14 @@ namespace JustEat.StatsD.Tests.Extensions
         public void Timing(TimeSpan duration, string bucket)
         {
             CallCount++;
+            LastDuration = duration;
             BucketNames.Add(bucket);
         }
 
         public void Timing(TimeSpan duration, double sampleRate, string bucket)
         {
             CallCount++;
+            LastDuration = duration;
             BucketNames.Add(bucket);
         }
 

--- a/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -1,11 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace JustEat.StatsD.Tests.Extensions
 {
-    class FakePublisher : IStatsDPublisher
+    class FakeStatsPublisher : IStatsDPublisher
     {
         public int CallCount { get; set; }
         public int DisposeCount { get; set; }
+        public List<string> BucketNames { get; private set; }
+
+        public FakeStatsPublisher()
+        {
+            BucketNames = new List<string>();
+        }
 
         public void Dispose()
         {
@@ -15,66 +22,79 @@ namespace JustEat.StatsD.Tests.Extensions
         public void Increment(string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Increment(long value, string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Increment(long value, double sampleRate, string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Increment(long value, double sampleRate, params string[] buckets)
         {
             CallCount++;
+            BucketNames.AddRange(buckets);
         }
 
         public void Decrement(string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Decrement(long value, string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Decrement(long value, double sampleRate, string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Decrement(long value, double sampleRate, params string[] buckets)
         {
             CallCount++;
+            BucketNames.AddRange(buckets);
         }
 
         public void Gauge(long value, string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Gauge(long value, string bucket, DateTime timestamp)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Timing(TimeSpan duration, string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Timing(TimeSpan duration, double sampleRate, string bucket)
         {
             CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void MarkEvent(string name)
         {
             CallCount++;
+            BucketNames.Add(name);
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -73,6 +73,8 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="EndpointLookups\CachedDnsEndpointMapper\WhenSendingMetricsToStatsD.cs" />
+    <Compile Include="Extensions\ExtensionsTests.cs" />
+    <Compile Include="Extensions\FakePublisher.cs" />
     <Compile Include="PacketBuilderTests.cs" />
     <Compile Include="WhenSendingMetricsToStatsD.cs" />
     <Compile Include="WhenTestingTimers.cs" />

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -74,7 +74,7 @@
     </Compile>
     <Compile Include="EndpointLookups\CachedDnsEndpointMapper\WhenSendingMetricsToStatsD.cs" />
     <Compile Include="Extensions\ExtensionsTests.cs" />
-    <Compile Include="Extensions\FakePublisher.cs" />
+    <Compile Include="Extensions\FakeStatsPublisher.cs" />
     <Compile Include="PacketBuilderTests.cs" />
     <Compile Include="WhenSendingMetricsToStatsD.cs" />
     <Compile Include="WhenTestingTimers.cs" />

--- a/src/JustEat.StatsD/DisposableTimer.cs
+++ b/src/JustEat.StatsD/DisposableTimer.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace JustEat.StatsD
+{
+    public class DisposableTimer : IDisposable
+    {
+        private bool _disposed;
+        private IStatsDPublisher _publisher;
+        private Stopwatch _stopwatch;
+        private readonly string _bucket;
+
+        public DisposableTimer(IStatsDPublisher publisher, string bucket)
+        {
+            if (publisher == null)
+            {
+                throw new ArgumentNullException("publisher");
+            }
+
+            if (string.IsNullOrEmpty(bucket))
+            {
+                throw new ArgumentNullException("bucket");
+            }
+
+            _publisher = publisher;
+            _bucket = bucket;
+            _stopwatch = Stopwatch.StartNew();
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                _stopwatch.Stop();
+
+                _publisher.Timing(_stopwatch.Elapsed, _bucket);
+                
+                _stopwatch = null;
+                _publisher = null;
+            }
+        }
+    }
+}

--- a/src/JustEat.StatsD/DisposableTimer.cs
+++ b/src/JustEat.StatsD/DisposableTimer.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace JustEat.StatsD
 {
-    public class DisposableTimer : IDisposable
+    internal class DisposableTimer : IDisposable
     {
         private bool _disposed;
         private IStatsDPublisher _publisher;

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -57,6 +57,8 @@
     <Compile Include="StatsDImmediatePublisher.cs" />
     <Compile Include="StatsDMessageFormatter.cs" />
     <Compile Include="StatsDUdpClient.cs" />
+    <Compile Include="DisposableTimer.cs" />
+    <Compile Include="TimerExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="JustEat.StatsD.nuspec" />

--- a/src/JustEat.StatsD/TimerExtensions.cs
+++ b/src/JustEat.StatsD/TimerExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace JustEat.StatsD
 {
@@ -17,6 +18,14 @@ namespace JustEat.StatsD
             }
         }
 
+        public static async Task Time(this IStatsDPublisher publisher, string bucket, Func<Task> action)
+        {
+            using (StartTimer(publisher, bucket))
+            {
+                await action();
+            }
+        }
+
         public static T Time<T>(this IStatsDPublisher publisher, string bucket, Func<T> func)
         {
             using (StartTimer(publisher, bucket))
@@ -24,5 +33,14 @@ namespace JustEat.StatsD
                 return func();
             }
         }
+
+        public static async Task<T> Time<T>(this IStatsDPublisher publisher, string bucket, Func<Task<T>> func)
+        {
+            using (StartTimer(publisher, bucket))
+            {
+                return await func();
+            }
+        }
+
     }
 }

--- a/src/JustEat.StatsD/TimerExtensions.cs
+++ b/src/JustEat.StatsD/TimerExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace JustEat.StatsD
+{
+    /// <summary>
+    /// Usage:
+    /// 
+    ///  timing a block of code in a using statment:
+    ///  using (stats.StartTimer("someStat"))
+    ///  {
+    ///     DoSomething();
+    ///  }
+    /// 
+    ///  timing a lambda without a return value:
+    /// stats.Time("someStat", () => DoSomething());
+    /// 
+    ///  timing a lambda with a return value:
+    /// var result = stats.Time("someStat", () => GetSomething());
+    /// </summary>
+    public static class TimerExtensions
+    {
+        public static DisposableTimer StartTimer(this IStatsDPublisher publisher, string bucket)
+        {
+            return new DisposableTimer(publisher, bucket);
+        }
+
+        public static void Time(this IStatsDPublisher publisher, string bucket, Action action)
+        {
+            using (StartTimer(publisher, bucket))
+            {
+                action();
+            }
+        }
+
+        public static T Time<T>(this IStatsDPublisher publisher, string bucket, Func<T> func)
+        {
+            using (StartTimer(publisher, bucket))
+            {
+                return func();
+            }
+        }
+    }
+}

--- a/src/JustEat.StatsD/TimerExtensions.cs
+++ b/src/JustEat.StatsD/TimerExtensions.cs
@@ -2,21 +2,6 @@
 
 namespace JustEat.StatsD
 {
-    /// <summary>
-    /// Usage:
-    /// 
-    ///  timing a block of code in a using statment:
-    ///  using (stats.StartTimer("someStat"))
-    ///  {
-    ///     DoSomething();
-    ///  }
-    /// 
-    ///  timing a lambda without a return value:
-    /// stats.Time("someStat", () => DoSomething());
-    /// 
-    ///  timing a lambda with a return value:
-    /// var result = stats.Time("someStat", () => GetSomething());
-    /// </summary>
     public static class TimerExtensions
     {
         public static IDisposable StartTimer(this IStatsDPublisher publisher, string bucket)

--- a/src/JustEat.StatsD/TimerExtensions.cs
+++ b/src/JustEat.StatsD/TimerExtensions.cs
@@ -19,7 +19,7 @@ namespace JustEat.StatsD
     /// </summary>
     public static class TimerExtensions
     {
-        public static DisposableTimer StartTimer(this IStatsDPublisher publisher, string bucket)
+        public static IDisposable StartTimer(this IStatsDPublisher publisher, string bucket)
         {
             return new DisposableTimer(publisher, bucket);
         }


### PR DESCRIPTION
Easy to use timers.

usage: given an existing instance of `IStatsDPublisher`   you can do:

```
    //  timing a block of code in a using statment:
   using (stats.StartTimer("someStat"))
   {
      DoSomething();
   }
 
   //  timing a lambda without a return value:
   stats.Time("someStat", () => DoSomething());

    //  timing a lambda with a return value:
    var result = stats.Time("someStat", () => GetSomething());

    // works with async
    using (stats.StartTimer("someStat"))
    {
        await DoSomethingAsync();
    }

    // and correctly times async lambdas using the usual syntax:
    var result = await stats.Time("someStat", async () => await GetSomethingAsync());
    
```
