### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This syntax for timers less typing in simple cases, where you always want to tim
    }
 ```
  
-The `StartTimer` returns an `IDisposable` that wraps a stopwatch. The stopwatch is automatically stopped and the metric sent when it falls out of scope on the closing `}` of the using statement.
+The `StartTimer` returns an `IDisposable` that wraps a stopwatch. The stopwatch is automatically stopped and the metric sent when it falls out of scope on the closing `}` of the `using` statement.
  
 ```csharp
    //  timing a lambda without a return value:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 ### TL;DR
 
-We use this within our components to publish [statsd](http://github.com/etsy/statsd) metrics from .Net code.
-
-We've been using this in most of our things, since around 2013.
+We use this within our components to publish [statsd](http://github.com/etsy/statsd) metrics from .NET code. We've been using this in most of our things, since around 2013.
 
 ### Features
 
@@ -17,7 +15,7 @@ We've been using this in most of our things, since around 2013.
 
 `IStatsDPublisher` is the interface that you will use in most circumstances. With this you can `Increment` or `Decrement` an event, and send values for a `Gauge` or `Timing`.
 
-The concrete class that implements `IStatsDPublisher` is `StatsDImmediatePublisher`. For the constructor parameters, you will need the statsd server host name. You can change the standard port (8125). You can also append a prefix to all stats. These values often come from configuration as the host name and/or prefix may vary between test and production environments.
+The concrete class that implements `IStatsDPublisher` is `StatsDImmediatePublisher`. For the constructor parameters, you will need the statsd server host name. You can change the standard port (8125). You can also prepend a prefix to all stats. These values often come from configuration as the host name and/or prefix may vary between test and production environments.
 
 #### Example of setting up a StatsDPublisher
 
@@ -40,14 +38,14 @@ An example of Ioc in NInject for statsd publisher with values from configuration
 Given an existing instance of `IStatsDPublisher` called `stats` you can do for e.g.:
 
 ```csharp
-		stats.Increment("DoSomething-Attempt");
+		stats.Increment("DoSomething.Attempt");
 		var stopWatch = Stopwatch.StartNew();
         var success = DoSomething();
 
 		stopWatch.Stop();
 		if (success)
         {
-			stats.Timing("DoSomething-Success", stopWatch.Elapsed);
+			stats.Timing("DoSomething.Success", stopWatch.Elapsed);
 		}
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ An example of Ioc in NInject for statsd publisher with values from configuration
 
 ```
 
-#### Example of using the interface. 
+#### Example of using the interface
+
 Given an existing instance of `IStatsDPublisher` called `stats` you can do for e.g.:
 
 ```csharp
@@ -50,7 +51,7 @@ Given an existing instance of `IStatsDPublisher` called `stats` you can do for e
 		}
 ```
 
-#### Simple timers. 
+#### Simple timers
 
 This syntax for timers less typing in simple cases, where you always want to time the operation, and always with the same stat name. Given an existing instance of `IStatsDPublisher` you can do:
 
@@ -60,9 +61,11 @@ This syntax for timers less typing in simple cases, where you always want to tim
    {
       DoSomething();
    }
+```
  
 The `StartTimer` returns an `IDisposable` that wraps a stopwatch. The stopwatch is automatically stopped and the metric sent when it falls out of scope on the closing `}` of the using statement.
  
+```csharp
    //  timing a lambda without a return value:
    stats.Time("someStat", () => DoSomething());
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,9 @@
 
 ### TL;DR
 
-We use this within our components to publish [statsd](http://github.com/etsy/statsd) metrics.
+We use this within our components to publish [statsd](http://github.com/etsy/statsd) metrics from .Net code.
 
-### In detail
-
-There's really not much else to say :-)
-
-We've been using this in most of our things, mostly unchanged, since around 2013.
+We've been using this in most of our things, since around 2013.
 
 ### Features
 
@@ -19,15 +15,15 @@ We've been using this in most of our things, mostly unchanged, since around 2013
 
 ####
 
-`IStatsDPublisher` is the interface that you will use in most circumstances. Use an instance of this in order to send events, timers and gauges.
+`IStatsDPublisher` is the interface that you will use in most circumstances. You can `Increment` or `Decrement` an event, and send values for a `Gauge` or `Timing`.
 
 The concrete class that implements is `IStatsDPublisher` is `StatsDImmediatePublisher`. For the constructor parameters, you will need to statsd server host name. You can also append a prefix to all stats. Often one of both of these values vary between test and producion environments.
 
 example of Ioc in NInject for statsd publisher with values from config:
 ```csharp
-	string statsdHostName = GetConfigValue("statsd.hostname");
-	int statsdPort = GetConfigValueInt("statsd.hostname");
-	string statsdPrefix = GetConfigValue("statsd.hostname");
+	string statsdHostName =  ConfigurationManager.AppSettings["statsd.hostname"];
+	int statsdPort = int.Parse(ConfigurationManager.AppSettings["statsd.port"]);
+	string statsdPrefix =  ConfigurationManager.AppSettings["statsd.prefix"];
 		
 	Bind<IStatsDPublisher>().To<StatsDImmediatePublisher>()
         .WithConstructorArgument("cultureInfo", CultureInfo.InvariantCulture)
@@ -40,6 +36,7 @@ example of Ioc in NInject for statsd publisher with values from config:
 Timing with the interface. Given an existing instance of `IStatsDPublisher` you can do:
 
 ```csharp
+		stats.Increment("DoSomething.Attempt");
 		var stopWatch = Stopwatch.StartNew();
 
         var success = DoSomething();
@@ -54,7 +51,7 @@ Timing with the interface. Given an existing instance of `IStatsDPublisher` you 
 ####
 Simple timers. 
 
-This syntax is simpler; for cases where you always want to time the operation, and always with the same stat name. Given an existing instance of `IStatsDPublisher` you can do:
+This syntax for timers is simpler. It is useful in cases where you always want to time the operation, and always with the same stat name. Given an existing instance of `IStatsDPublisher` you can do:
 
 ```csharp
     //  timing a block of code in a using statement:


### PR DESCRIPTION
better wordings, fixes to code samples and added section headings

open questions:
- what does "IStatsDPublisher.MarkEvent" do?

- In the context of an IoC container, can `IStatsDPublisher` be a singleton, must it be transient or some other lifestyle?