### PR TITLE
Extensions test refactor

### DIFF
--- a/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
@@ -22,10 +22,23 @@ namespace JustEat.StatsD.Tests.Extensions
             }
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
 
             AssertDurationIsInExpectedRange(publisher.LastDuration);
+        }
+
+
+        [Test]
+        public void ShouldNotDisposePublisherAfterStatSent()
+        {
+            var publisher = new FakeStatsPublisher();
+
+            using (publisher.StartTimer("stat"))
+            {
+                Delay();
+            }
+
+            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
         }
 
         [Test]
@@ -44,7 +57,6 @@ namespace JustEat.StatsD.Tests.Extensions
             }
 
             Assert.That(publisher.CallCount, Is.EqualTo(2));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat1", "stat2" }));
             AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
@@ -60,7 +72,6 @@ namespace JustEat.StatsD.Tests.Extensions
             }
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
             AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
@@ -81,7 +92,6 @@ namespace JustEat.StatsD.Tests.Extensions
             }
 
             Assert.That(publisher.CallCount, Is.EqualTo(2));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat1", "stat2" }));
             AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
@@ -93,7 +103,6 @@ namespace JustEat.StatsD.Tests.Extensions
             publisher.Time("stat", () => Delay());
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
             AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
@@ -106,7 +115,6 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(answer, Is.EqualTo(42));
             Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
             AssertDurationIsInExpectedRange(publisher.LastDuration);
         }
@@ -118,7 +126,6 @@ namespace JustEat.StatsD.Tests.Extensions
             await publisher.Time("stat", async () => await DelayAsync());
 
             Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
         }
 
@@ -139,7 +146,6 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(answer, Is.EqualTo(42));
             Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
         }
 
@@ -181,7 +187,6 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(duration, Is.GreaterThanOrEqualTo(expectedDelayLower));
             Assert.That(duration, Is.LessThanOrEqualTo(expectedDelayUpper));
-
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -21,12 +20,9 @@ namespace JustEat.StatsD.Tests.Extensions
                 Delay();
             }
 
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
-
-            AssertDurationIsInExpectedRange(publisher.LastDuration);
+            PublisherAssertions.SingleStatNameIs(publisher, "stat");
+            PublisherAssertions.LastDurationIs(publisher, StandardDelayMillis);
         }
-
 
         [Test]
         public void ShouldNotDisposePublisherAfterStatSent()
@@ -58,7 +54,7 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(2));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat1", "stat2" }));
-            AssertDurationIsInExpectedRange(publisher.LastDuration);
+            PublisherAssertions.LastDurationIs(publisher, StandardDelayMillis);
         }
 
         [Test]
@@ -66,14 +62,13 @@ namespace JustEat.StatsD.Tests.Extensions
         {
             var publisher = new FakeStatsPublisher();
 
-            using (publisher.StartTimer("stat"))
+            using (publisher.StartTimer("statWithAsync"))
             {
                 await DelayAsync();
             }
 
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
-            AssertDurationIsInExpectedRange(publisher.LastDuration);
+            PublisherAssertions.SingleStatNameIs(publisher, "statWithAsync");
+            PublisherAssertions.LastDurationIs(publisher, StandardDelayMillis);
         }
 
         [Test]
@@ -93,40 +88,37 @@ namespace JustEat.StatsD.Tests.Extensions
 
             Assert.That(publisher.CallCount, Is.EqualTo(2));
             Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat1", "stat2" }));
-            AssertDurationIsInExpectedRange(publisher.LastDuration);
+            PublisherAssertions.LastDurationIs(publisher, StandardDelayMillis);
         }
 
         [Test]
         public void CanRecordStatInAction()
         {
             var publisher = new FakeStatsPublisher();
-            publisher.Time("stat", () => Delay());
+            publisher.Time("statOverAction", () => Delay());
 
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
-            AssertDurationIsInExpectedRange(publisher.LastDuration);
+            PublisherAssertions.SingleStatNameIs(publisher, "statOverAction");
+            PublisherAssertions.LastDurationIs(publisher, StandardDelayMillis);
         }
 
         [Test]
         public void CanRecordStatInFunction()
         {
             var publisher = new FakeStatsPublisher();
-            var answer = publisher.Time("stat", () => DelayedAnswer());
+            var answer = publisher.Time("statOverFunc", () => DelayedAnswer());
 
             Assert.That(answer, Is.EqualTo(42));
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
-            AssertDurationIsInExpectedRange(publisher.LastDuration);
+            PublisherAssertions.SingleStatNameIs(publisher, "statOverFunc");
+            PublisherAssertions.LastDurationIs(publisher, StandardDelayMillis);
         }
 
         [Test]
         public async Task CanRecordStatInAsyncAction()
         {
             var publisher = new FakeStatsPublisher();
-            await publisher.Time("stat", async () => await DelayAsync());
+            await publisher.Time("statOverAsyncAction", async () => await DelayAsync());
 
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
+            PublisherAssertions.SingleStatNameIs(publisher, "statOverAsyncAction");
         }
 
         [Test]
@@ -135,18 +127,17 @@ namespace JustEat.StatsD.Tests.Extensions
             var publisher = new FakeStatsPublisher();
             await publisher.Time("stat", async () => await DelayAsync());
 
-            AssertDurationIsInExpectedRange(publisher.LastDuration);
+            PublisherAssertions.LastDurationIs(publisher, StandardDelayMillis);
         }
 
         [Test]
         public async Task CanRecordStatInAsyncFunction()
         {
             var publisher = new FakeStatsPublisher();
-            var answer = await publisher.Time("stat", async () => await DelayedAnswerAsync());
+            var answer = await publisher.Time("statOverAsyncFunc", async () => await DelayedAnswerAsync());
 
             Assert.That(answer, Is.EqualTo(42));
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "stat" }));
+            PublisherAssertions.SingleStatNameIs(publisher, "statOverAsyncFunc");
         }
 
         [Test]
@@ -155,7 +146,7 @@ namespace JustEat.StatsD.Tests.Extensions
             var publisher = new FakeStatsPublisher();
             await publisher.Time("stat", async () => await DelayedAnswerAsync());
 
-            AssertDurationIsInExpectedRange(publisher.LastDuration);
+            PublisherAssertions.LastDurationIs(publisher, StandardDelayMillis);
         }
 
         private void Delay()
@@ -178,15 +169,6 @@ namespace JustEat.StatsD.Tests.Extensions
         {
             await Task.Delay(StandardDelayMillis);
             return 42;
-        }
-
-        private void AssertDurationIsInExpectedRange(TimeSpan duration)
-        {
-            var expectedDelayLower = TimeSpan.FromMilliseconds(StandardDelayMillis);
-            var expectedDelayUpper = TimeSpan.FromMilliseconds(StandardDelayMillis * 2);
-
-            Assert.That(duration, Is.GreaterThanOrEqualTo(expectedDelayLower));
-            Assert.That(duration, Is.LessThanOrEqualTo(expectedDelayUpper));
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace JustEat.StatsD.Tests.Extensions
 {
-    class FakeStatsPublisher : IStatsDPublisher
+    public class FakeStatsPublisher : IStatsDPublisher
     {
         public int CallCount { get; set; }
         public int DisposeCount { get; set; }

--- a/src/JustEat.StatsD.Tests/Extensions/PublisherAssertions.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/PublisherAssertions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace JustEat.StatsD.Tests.Extensions
+{
+    public static class PublisherAssertions
+    {
+        public static void SingleStatNameIs(FakeStatsPublisher publisher, string statName)
+        {
+            Assert.That(publisher.CallCount, Is.EqualTo(1));
+            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+
+            Assert.That(publisher.BucketNames.Count, Is.EqualTo(1));
+            Assert.That(publisher.BucketNames[0], Is.EqualTo(statName));
+        }
+
+        public static void LastDurationIs(FakeStatsPublisher publisher, int expectedMillis)
+        {
+            DurationIsMoreOrLess(publisher.LastDuration, TimeSpan.FromMilliseconds(expectedMillis));
+        }
+
+        private static void DurationIsMoreOrLess(TimeSpan expected, TimeSpan actual)
+        {
+            TimeSpan delta = TimeSpan.FromMilliseconds(100);
+
+            var expectedLower = expected.Subtract(delta);
+            var expectedUpper = expected.Add(delta);
+
+            Assert.That(actual, Is.GreaterThanOrEqualTo(expectedLower));
+            Assert.That(actual, Is.LessThanOrEqualTo(expectedUpper));
+        }
+    }
+}

--- a/src/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using NUnit.Framework;
 
@@ -18,9 +17,7 @@ namespace JustEat.StatsD.Tests.Extensions
                 Delay();
             }
 
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "initialStat" }));
+            AssertStatNameIs(publisher, "initialStat");
         }
 
         [Test]
@@ -34,9 +31,7 @@ namespace JustEat.StatsD.Tests.Extensions
                 timer.StatName = "changedValue";
             }
 
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "changedValue" }));
+            AssertStatNameIs(publisher, "changedValue");
         }
 
         [Test]
@@ -50,9 +45,7 @@ namespace JustEat.StatsD.Tests.Extensions
                 timer.StatName += "More";
             }
 
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "Some.More" }));
+            AssertStatNameIs(publisher, "Some.More");
         }
 
 
@@ -64,7 +57,6 @@ namespace JustEat.StatsD.Tests.Extensions
             Assert.Throws<ArgumentNullException>(() => publisher.StartTimer(string.Empty));
 
             Assert.That(publisher.CallCount, Is.EqualTo(0));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.Empty);
         }
 
@@ -83,7 +75,6 @@ namespace JustEat.StatsD.Tests.Extensions
             });
 
             Assert.That(publisher.CallCount, Is.EqualTo(0));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
             Assert.That(publisher.BucketNames, Is.Empty);
         }
 
@@ -107,9 +98,7 @@ namespace JustEat.StatsD.Tests.Extensions
             }
 
             Assert.That(failCount, Is.EqualTo(1));
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-            Assert.That(publisher.BucketNames, Is.EquivalentTo(new List<string> { "initialStat" }));
+            AssertStatNameIs(publisher, "initialStat");
         }
 
         private void Delay()
@@ -121,6 +110,15 @@ namespace JustEat.StatsD.Tests.Extensions
         private void Fail()
         {
             throw new Exception("Deliberate fail");
+        }
+
+        private void AssertStatNameIs(FakeStatsPublisher publisher, string statName)
+        {
+            Assert.That(publisher.CallCount, Is.EqualTo(1));
+            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
+
+            Assert.That(publisher.BucketNames.Count, Is.EqualTo(1));
+            Assert.That(publisher.BucketNames[0], Is.EqualTo(statName));
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
@@ -17,7 +17,7 @@ namespace JustEat.StatsD.Tests.Extensions
                 Delay();
             }
 
-            AssertStatNameIs(publisher, "initialStat");
+            PublisherAssertions.SingleStatNameIs(publisher, "initialStat");
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace JustEat.StatsD.Tests.Extensions
                 timer.StatName = "changedValue";
             }
 
-            AssertStatNameIs(publisher, "changedValue");
+            PublisherAssertions.SingleStatNameIs(publisher, "changedValue");
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace JustEat.StatsD.Tests.Extensions
                 timer.StatName += "More";
             }
 
-            AssertStatNameIs(publisher, "Some.More");
+            PublisherAssertions.SingleStatNameIs(publisher, "Some.More");
         }
 
 
@@ -98,7 +98,7 @@ namespace JustEat.StatsD.Tests.Extensions
             }
 
             Assert.That(failCount, Is.EqualTo(1));
-            AssertStatNameIs(publisher, "initialStat");
+            PublisherAssertions.SingleStatNameIs(publisher, "initialStat");
         }
 
         private void Delay()
@@ -110,15 +110,6 @@ namespace JustEat.StatsD.Tests.Extensions
         private void Fail()
         {
             throw new Exception("Deliberate fail");
-        }
-
-        private void AssertStatNameIs(FakeStatsPublisher publisher, string statName)
-        {
-            Assert.That(publisher.CallCount, Is.EqualTo(1));
-            Assert.That(publisher.DisposeCount, Is.EqualTo(0));
-
-            Assert.That(publisher.BucketNames.Count, Is.EqualTo(1));
-            Assert.That(publisher.BucketNames[0], Is.EqualTo(statName));
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -73,6 +73,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="EndpointLookups\CachedDnsEndpointMapper\WhenSendingMetricsToStatsD.cs" />
+    <Compile Include="Extensions\PublisherAssertions.cs" />
     <Compile Include="Extensions\SimpleTimerStatNameTests.cs" />
     <Compile Include="Extensions\ExtensionsTests.cs" />
     <Compile Include="Extensions\FakeStatsPublisher.cs" />


### PR DESCRIPTION
- Test refactoring for readability
- Extracted common asserts into helper class for use in both test files …
- use a different stat name for each syntax form in ExtensionsTests