### PR TITLE
Target .NET 4.5.0

### DIFF
--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JustEat.StatsD</RootNamespace>
     <AssemblyName>JustEat.StatsD</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <OutputPath>..\..\out\$(Platform)\$(TargetFrameworkVersion)\$(Configuration)\</OutputPath>


### PR DESCRIPTION
While Microsoft no longer supports .NET 4.5.0, Mono doesn't yet support everything from .NET 4.5.2 so targeting .NET 4.5.2 means this library can't be used on Mono.

This PR changes the target of the JustEat.StatsD project to target .NET 4.5.0, thus allowing use on Mono.