### PR TITLE
Exclude prerelease versions from NuGet badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JustEat.StatsD
 
-[![NuGet version](https://buildstats.info/nuget/JustEat.StatsD)](http://www.nuget.org/packages/JustEat.StatsD)
+[![NuGet version](https://buildstats.info/nuget/JustEat.StatsD?includePreReleases=false)](http://www.nuget.org/packages/JustEat.StatsD)
 [![Build status](https://img.shields.io/appveyor/ci/justeattech/justeat-statsd/master.svg)](https://ci.appveyor.com/project/justeattech/JustEat.StatsD)
 
 ## The point


### PR DESCRIPTION
Exclude prerelease versions from being displayed as the latest version in the NuGet badge.