### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
-dotnet restore --verbosity minimal
-dotnet build src/JustEat.StatsD --framework "netstandard1.3"
+export artifacts=$(dirname "$(readlink -f "$0")")/artifacts
+export configuration=Release
+
+dotnet restore JustEat.StatsD.sln --verbosity minimal || exit 1
+dotnet build src/JustEat.StatsD/JustEat.StatsD.csproj --output $artifacts --configuration $configuration --framework "netstandard1.6" || exit 1
+dotnet test src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj --output $artifacts --configuration $configuration --framework "netcoreapp1.0" || exit 1


### PR DESCRIPTION
Update ```build.sh``` for building with .NET Core SDK 1.0.1 in Travis CI.