### PR TITLE
Rename the publisher

### DIFF
--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -6,19 +6,19 @@ namespace JustEat.StatsD
     /// <summary>
     ///     Will synchronously publish stats at statsd as you make calls; will not batch sends.
     /// </summary>
-    public class StatsDImmediatePublisher : IStatsDPublisher
+    public class StatsDPublisher : IStatsDPublisher
     {
         private static readonly CultureInfo SafeDefaultCulture = new CultureInfo(StatsDMessageFormatter.SafeDefaultIsoCultureId);
         private readonly StatsDMessageFormatter _formatter;
         private readonly IStatsDTransport _transport;
 
-        public StatsDImmediatePublisher(CultureInfo cultureInfo, string hostNameOrAddress, int port = 8125, string prefix = "")
+        public StatsDPublisher(CultureInfo cultureInfo, string hostNameOrAddress, int port = 8125, string prefix = "")
         {
             _formatter = new StatsDMessageFormatter(cultureInfo, prefix);
             _transport = new StatsDUdpTransport(hostNameOrAddress, port);
         }
 
-        public StatsDImmediatePublisher(string hostNameOrAddress, int port = 8125, string prefix = "") : this(SafeDefaultCulture, hostNameOrAddress, port, prefix) {}
+        public StatsDPublisher(string hostNameOrAddress, int port = 8125, string prefix = "") : this(SafeDefaultCulture, hostNameOrAddress, port, prefix) {}
 
         public void Increment(string bucket)
         {


### PR DESCRIPTION
It's the default publisher. it's the only publisher. calling it the "immediate" publisher is overly verbose.