### PR TITLE
Constructor params object

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,7 @@ An example of a very simple statsd publisher configuration, using the default va
 
 ```csharp
 
-var statsDConfig = new StatsDConfiguration
-{
-  HostNameOrAddress = "metrics_server.mycompany.com"
-};
+var statsDConfig = new StatsDConfiguration { Host = "metrics_server.mycompany.com" };
 var statsDPublisher = new StatsDPublisher(statsDConfig);
 ```
 
@@ -51,7 +48,7 @@ string statsdPrefix =  ConfigurationManager.AppSettings["statsd.prefix"];
 // it can be a preconfigured singleton instance
 var statsDConfig = new StatsDConfiguration
 {
-  HostNameOrAddress = statsdHostName,
+  Host = statsdHostName,
   Port = statsdPort,
   Prefix = statsdPrefix,
   Culture = CultureInfo.InvariantCulture

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An example of a very simple statsd publisher configuration, using the default va
 ```csharp
 
 var statsDConfig = new StatsDConfiguration { Host = "metrics_server.mycompany.com" };
-var statsDPublisher = new StatsDPublisher(statsDConfig);
+IStatsDPublisher statsDPublisher = new StatsDPublisher(statsDConfig);
 ```
 
 An example of IoC in NInject for statsd publisher with values for all options, read from configuration:

--- a/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
+++ b/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Shouldly;
+using Xunit;
+
+namespace JustEat.StatsD
+{
+    public class WhenCreatingStatsDPublisher
+    {
+        [Fact]
+        public void ConfigurationIsValidWithHostName()
+        {
+            var validConfig = new StatsDConfiguration
+            {
+                Host = "someserver.somewhere.com"
+            };
+
+            var stats = new StatsDPublisher(validConfig);
+
+            stats.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ConfigurationIsValidWithHostIp()
+        {
+            var validConfig = new StatsDConfiguration
+            {
+                Host = "10.0.1.2"
+            };
+
+            var stats = new StatsDPublisher(validConfig);
+
+            stats.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ConfigurationIsNull()
+        {
+            StatsDConfiguration noConfig = null;
+
+            Should.Throw<ArgumentNullException>(
+             () => new StatsDPublisher(noConfig));
+        }
+
+        [Fact]
+        public void ConfigurationHasNoCulture()
+        {
+            var badConfig = new StatsDConfiguration
+            {
+                Host = "someserver.somewhere.com",
+                Culture = null
+            };
+
+            Should.Throw<ArgumentNullException>(
+             () => new StatsDPublisher(badConfig));
+        }
+
+        [Fact]
+        public void ConfigurationHasNoHost()
+        {
+            var badConfig = new StatsDConfiguration
+            {
+                Host = null
+            };
+
+            Should.Throw<ArgumentNullException>(
+             () => new StatsDPublisher(badConfig));
+        }
+    }
+}

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -4,14 +4,12 @@ namespace JustEat.StatsD
 {
     public class StatsDConfiguration
     {
-        private const string SafeDefaultIsoCultureId = "en-US";
-        private static readonly CultureInfo SafeDefaultCulture = new CultureInfo(SafeDefaultIsoCultureId);
         public const int DefaultPort = 8125;
 
         public string Host { get; set; }
 
         public int Port { get; set; } = DefaultPort;
         public string Prefix { get; set; } = string.Empty;
-        public CultureInfo Culture { get; set; } = SafeDefaultCulture;
+        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
     }
 }

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -4,8 +4,9 @@ namespace JustEat.StatsD
 {
     public class StatsDConfiguration
     {
+        private const string SafeDefaultIsoCultureId = "en-US";
+        private static readonly CultureInfo SafeDefaultCulture = new CultureInfo(SafeDefaultIsoCultureId);
         public const int DefaultPort = 8125;
-        private static readonly CultureInfo SafeDefaultCulture = new CultureInfo(StatsDMessageFormatter.SafeDefaultIsoCultureId);
 
         public string Host { get; set; }
 

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+
+namespace JustEat.StatsD
+{
+    public class StatsDConfiguration
+    {
+        public const int DefaultPort = 8125;
+        private static readonly CultureInfo SafeDefaultCulture = new CultureInfo(StatsDMessageFormatter.SafeDefaultIsoCultureId);
+
+        public int Port { get; set; } = DefaultPort;
+
+        public string HostNameOrAddress { get; set; }
+
+        public string Prefix { get; set; } = string.Empty;
+        public CultureInfo Culture { get; set; } = SafeDefaultCulture;
+    }
+}

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace JustEat.StatsD
 {
@@ -7,10 +7,9 @@ namespace JustEat.StatsD
         public const int DefaultPort = 8125;
         private static readonly CultureInfo SafeDefaultCulture = new CultureInfo(StatsDMessageFormatter.SafeDefaultIsoCultureId);
 
+        public string Host { get; set; }
+
         public int Port { get; set; } = DefaultPort;
-
-        public string HostNameOrAddress { get; set; }
-
         public string Prefix { get; set; } = string.Empty;
         public CultureInfo Culture { get; set; } = SafeDefaultCulture;
     }

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -23,6 +23,11 @@ namespace JustEat.StatsD
 
             public StatsDMessageFormatter(CultureInfo cultureInfo, string prefix)
         {
+            if (cultureInfo == null)
+            {
+                throw new ArgumentNullException(nameof(cultureInfo));
+            }
+
             _cultureInfo = cultureInfo;
             _prefix = prefix;
 

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -10,22 +10,19 @@ namespace JustEat.StatsD
 #endif
     public class StatsDMessageFormatter
     {
-        public const string SafeDefaultIsoCultureId = "en-US";
         private const double DefaultSampleRate = 1.0;
 
-        [ThreadStatic] private static Random _random;
+        [ThreadStatic]
+        private static Random _random;
 
         private readonly CultureInfo _cultureInfo;
         private readonly string _prefix;
-
-        public StatsDMessageFormatter() : this(new CultureInfo(SafeDefaultIsoCultureId), prefix: "") {}
-
-        public StatsDMessageFormatter(string prefix = "") : this(new CultureInfo(SafeDefaultIsoCultureId), prefix) {}
 
         public StatsDMessageFormatter(CultureInfo ci, string prefix = "")
         {
             _cultureInfo = ci;
             _prefix = prefix;
+
             if (!string.IsNullOrWhiteSpace(_prefix))
             {
                 _prefix = _prefix + "."; // if we have something, then append a . to it to make concatenations easy.

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -18,9 +18,12 @@ namespace JustEat.StatsD
         private readonly CultureInfo _cultureInfo;
         private readonly string _prefix;
 
-        public StatsDMessageFormatter(CultureInfo ci, string prefix = "")
+        public StatsDMessageFormatter(CultureInfo cultureInfo)
+            : this(cultureInfo, string.Empty) {}
+
+            public StatsDMessageFormatter(CultureInfo cultureInfo, string prefix)
         {
-            _cultureInfo = ci;
+            _cultureInfo = cultureInfo;
             _prefix = prefix;
 
             if (!string.IsNullOrWhiteSpace(_prefix))

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -12,6 +12,11 @@ namespace JustEat.StatsD
 
         public StatsDPublisher(StatsDConfiguration configuration)
         {
+            if (configuration == null)
+            {
+               throw new ArgumentNullException(nameof(configuration));
+            }
+
             _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
             _transport = new StatsDUdpTransport(configuration.Host, configuration.Port);
         }

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -13,7 +13,7 @@ namespace JustEat.StatsD
         public StatsDPublisher(StatsDConfiguration configuration)
         {
             _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
-            _transport = new StatsDUdpTransport(configuration.HostNameOrAddress, configuration.Port);
+            _transport = new StatsDUdpTransport(configuration.Host, configuration.Port);
         }
 
         public void Increment(string bucket)

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -17,6 +17,11 @@ namespace JustEat.StatsD
                throw new ArgumentNullException(nameof(configuration));
             }
 
+            if (string.IsNullOrWhiteSpace(configuration.Host))
+            {
+                throw new ArgumentNullException(nameof(configuration.Host));
+            }
+
             _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
             _transport = new StatsDUdpTransport(configuration.Host, configuration.Port);
         }

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 
 namespace JustEat.StatsD
 {
@@ -8,17 +7,14 @@ namespace JustEat.StatsD
     /// </summary>
     public class StatsDPublisher : IStatsDPublisher
     {
-        private static readonly CultureInfo SafeDefaultCulture = new CultureInfo(StatsDMessageFormatter.SafeDefaultIsoCultureId);
         private readonly StatsDMessageFormatter _formatter;
         private readonly IStatsDTransport _transport;
 
-        public StatsDPublisher(CultureInfo cultureInfo, string hostNameOrAddress, int port = 8125, string prefix = "")
+        public StatsDPublisher(StatsDConfiguration configuration)
         {
-            _formatter = new StatsDMessageFormatter(cultureInfo, prefix);
-            _transport = new StatsDUdpTransport(hostNameOrAddress, port);
+            _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
+            _transport = new StatsDUdpTransport(configuration.HostNameOrAddress, configuration.Port);
         }
-
-        public StatsDPublisher(string hostNameOrAddress, int port = 8125, string prefix = "") : this(SafeDefaultCulture, hostNameOrAddress, port, prefix) {}
 
         public void Increment(string bucket)
         {

--- a/src/PerfTestHarness/Program.cs
+++ b/src/PerfTestHarness/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using JustEat.StatsD;
@@ -12,7 +13,7 @@ namespace PerfTestHarness
         {
             var iterations = Enumerable.Range(1, 500000);
             var client = new StatsDUdpTransport(10, "localhost", 3128);
-            var formatter = new StatsDMessageFormatter();
+            var formatter = new StatsDMessageFormatter(CultureInfo.InvariantCulture);
             var watch = new Stopwatch();
 
             Console.WriteLine("To start - hit ENTER.");


### PR DESCRIPTION
Replace all of the constructor params to `StatsDPublisher` - the `CultureInfo, string, int, string` with a new `StatsDConfiguration` type.

This is a breaking change for the config code of all clients.

The main reason that I prefer this style is that injecting a bunch of strings and ints into a constructor via IoC is error prone, tricky, verbose syntax that always varies from one IoC container to another.  So we replace [the primitive obsession](http://wiki.c2.com/?PrimitiveObsession) with strong typing, which IoC containers understand well. 

Off the back of that, the number of different constructor overloads and default params goes down since all the defaulting moves into this object. Should we need to add more config options, this will be simpler. 

I haven't looked at the `Host` configuration property which is stringly typed as either a host name or IP address, but that is a possibility afterwards.

What do you think?