### PR TITLE
Surface the Transport

### DIFF
--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -11,6 +11,9 @@ namespace JustEat.StatsD
         public string Host { get; set; }
 
         public int Port { get; set; } = DefaultPort;
+
+        public TimeSpan? DnsLookupInterval { get; set; } = DefaultDnsLookupInterval;
+
         public string Prefix { get; set; } = string.Empty;
         public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
     }

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -1,10 +1,12 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 
 namespace JustEat.StatsD
 {
     public class StatsDConfiguration
     {
         public const int DefaultPort = 8125;
+        public static readonly TimeSpan DefaultDnsLookupInterval = TimeSpan.FromMinutes(5);
 
         public string Host { get; set; }
 

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -41,7 +41,8 @@ namespace JustEat.StatsD
 
             _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
 
-            var endpointSource = EndpointParser.MakeEndPointSource(configuration.Host, configuration.Port, StatsDConfiguration.DefaultDnsLookupInterval);
+            var endpointSource = EndpointParser.MakeEndPointSource(
+                configuration.Host, configuration.Port, configuration.DnsLookupInterval);
             _transport = new StatsDUdpTransport(endpointSource);
         }
 

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JustEat.StatsD.EndpointLookups;
 
 namespace JustEat.StatsD
 {
@@ -9,6 +10,22 @@ namespace JustEat.StatsD
     {
         private readonly StatsDMessageFormatter _formatter;
         private readonly IStatsDTransport _transport;
+
+        public StatsDPublisher(StatsDConfiguration configuration, IStatsDTransport transport)
+        {
+            if (configuration == null)
+            {
+               throw new ArgumentNullException(nameof(configuration));
+            }
+
+            if (transport == null)
+            {
+               throw new ArgumentNullException(nameof(transport));
+            }
+
+            _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
+            _transport = transport;            
+        }
 
         public StatsDPublisher(StatsDConfiguration configuration)
         {
@@ -23,7 +40,9 @@ namespace JustEat.StatsD
             }
 
             _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
-            _transport = new StatsDUdpTransport(configuration.Host, configuration.Port, null);
+
+            var endpointSource = EndpointParser.MakeEndPointSource(configuration.Host, configuration.Port, StatsDConfiguration.DefaultDnsLookupInterval);
+            _transport = new StatsDUdpTransport(endpointSource);
         }
 
         public void Increment(string bucket)

--- a/src/JustEat.StatsD/StatsDUdpTransport.cs
+++ b/src/JustEat.StatsD/StatsDUdpTransport.cs
@@ -25,11 +25,6 @@ namespace JustEat.StatsD
             _endpointSource = endPointSource;
         }
 
-        public StatsDUdpTransport(string hostNameOrAddress, int port, TimeSpan? endpointCacheDuration)
-            : this(EndpointParser.MakeEndPointSource(hostNameOrAddress, port, endpointCacheDuration))
-        {
-        }
-
         public bool Send(string metric)
         {
             return Send(new[] {metric});

--- a/src/PerfTestHarness/Program.cs
+++ b/src/PerfTestHarness/Program.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using JustEat.StatsD;
+using JustEat.StatsD.EndpointLookups;
 
 namespace PerfTestHarness
 {
@@ -12,7 +13,8 @@ namespace PerfTestHarness
         private static void Main(string[] args)
         {
             var iterations = Enumerable.Range(1, 500000);
-            var client = new StatsDUdpTransport("localhost", 3128, TimeSpan.FromMinutes(1));
+            var endpoint = EndpointParser.MakeEndPointSource("localhost", 3128, TimeSpan.FromMinutes(1));
+            var client = new StatsDUdpTransport(endpoint);
             var formatter = new StatsDMessageFormatter(CultureInfo.InvariantCulture);
             var watch = new Stopwatch();
 

--- a/src/PerfTestHarness/Program.cs
+++ b/src/PerfTestHarness/Program.cs
@@ -13,7 +13,7 @@ namespace PerfTestHarness
         private static void Main(string[] args)
         {
             var iterations = Enumerable.Range(1, 500000);
-            var endpoint = EndpointParser.MakeEndPointSource("localhost", 3128, TimeSpan.FromMinutes(1));
+            var endpoint = EndpointParser.MakeEndPointSource("localhost", 3128, null);
             var client = new StatsDUdpTransport(endpoint);
             var formatter = new StatsDMessageFormatter(CultureInfo.InvariantCulture);
             var watch = new Stopwatch();


### PR DESCRIPTION
No breaking change in the simple case, but this gives options for injecting a custom transport into the `StatsDPublisher`.

My thinking is that `StatsDPublisher` is the top of the object hierarchy, so that's where assembling it all should happen,  and the `StatsDUdpTransport` can be dumber - it doesn't need to know about how to make an endpoint source, it just gets given one. So when there's a second transport, this endpoint-making code doesn't get duplicated.

`StatsDPublisher` surfaces a constructor with a `StatsDConfiguration` and a `IStatsDTransport` for the case where you use a different transport.

An alternative to this would be an enum in the config object, e.g. :
```csharp
// a different way to do it
var statsDConfig = new StatsDConfiguration 
  { 
     Host = "metrics_server.mycompany.com",
     Transport = StatsDTransport.Ip
};
IStatsDPublisher statsDPublisher = new StatsDPublisher(statsDConfig);
```

And then the `StatsDPublisher` constructor would have to create the appropriate  `IStatsDTransport` for the enum value.