### PR TITLE
Review transport

### DIFF
--- a/src/JustEat.StatsD.Tests/PacketBuilderTests.cs
+++ b/src/JustEat.StatsD.Tests/PacketBuilderTests.cs
@@ -6,7 +6,7 @@ namespace JustEat.StatsD.Tests
 {
     public class WhenBuildingPackets
     {
-        private byte[][] _bytes;
+        private readonly byte[][] _bytes;
 
         public WhenBuildingPackets()
         {

--- a/src/JustEat.StatsD/PacketBuilder.cs
+++ b/src/JustEat.StatsD/PacketBuilder.cs
@@ -1,16 +1,17 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
 namespace JustEat.StatsD
 {
-    /// <summary>	A helper class for turning a list of strings into a Udp packet.  </summary>
+    /// <summary>	
+    /// A helper class for turning a list of strings into a Udp packet. 
+    /// </summary>
     public static class PacketBuilder
     {
-        //private static readonly byte[] Terminator = Encoding.UTF8.GetBytes("\n");
-
         /// <summary>
-        ///     Takes a list of metric strings, separating them with newlines into a byte packet that is a maximum of 512 bytes in size.
+        /// Takes a list of metric strings, separating them with newlines 
+        /// into a list of byte packet, each a maximum of 512 bytes in size.
         /// </summary>
         /// <param name="metrics">	The metrics to act on. </param>
         /// <returns>	A streamed list of byte arrays, where each array is a maximum of 512 bytes. </returns>
@@ -20,10 +21,10 @@ namespace JustEat.StatsD
         }
 
         /// <summary>
-        ///     Takes a list of metric strings, separating them with newlines into a byte packet of the maximum specified size.
+        /// Takes a list of metric strings, separating them with newlines into a byte packet of the maximum specified size.
         /// </summary>
-        /// <param name="metrics">   	The metrics to act on. </param>
-        /// <param name="packetSize">	Maximum size of each packet (512 bytes recommended for Udp). </param>
+        /// <param name="metrics">The metrics to act on.</param>
+        /// <param name="packetSize">Maximum size of each packet (512 bytes recommended for Udp). </param>
         /// <returns>	A streamed list of byte arrays, where each array is a maximum of 512 bytes. </returns>
         public static IEnumerable<byte[]> ToMaximumBytePackets(this IEnumerable<string> metrics, int packetSize)
         {

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -43,7 +43,7 @@ namespace JustEat.StatsD
 
             var endpointSource = EndpointParser.MakeEndPointSource(
                 configuration.Host, configuration.Port, configuration.DnsLookupInterval);
-            _transport = new StatsDUdpTransport(endpointSource);
+            _transport = new UdpTransport(endpointSource);
         }
 
         public void Increment(string bucket)

--- a/src/JustEat.StatsD/StatsDUdpTransport.cs
+++ b/src/JustEat.StatsD/StatsDUdpTransport.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net.Sockets;
@@ -30,7 +29,6 @@ namespace JustEat.StatsD
             return Send(new[] {metric});
         }
 
-        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "This is one of the rare cases where eating exceptions is OK")]
         public bool Send(IEnumerable<string> metrics)
         {
             var data = EventArgsPool.Pop();

--- a/src/JustEat.StatsD/UdpTransport.cs
+++ b/src/JustEat.StatsD/UdpTransport.cs
@@ -8,14 +8,14 @@ using JustEat.StatsD.EndpointLookups;
 
 namespace JustEat.StatsD
 {
-    public class StatsDUdpTransport : IStatsDTransport
+    public class UdpTransport : IStatsDTransport
     {
         private static readonly SimpleObjectPool<SocketAsyncEventArgs> EventArgsPool
             = new SimpleObjectPool<SocketAsyncEventArgs>(30, pool => new PoolAwareSocketAsyncEventArgs(pool));
 
         private readonly IPEndPointSource _endpointSource;
 
-        public StatsDUdpTransport(IPEndPointSource endPointSource)
+        public UdpTransport(IPEndPointSource endPointSource)
         {
             if (endPointSource == null)
             {

--- a/src/PerfTestHarness/Program.cs
+++ b/src/PerfTestHarness/Program.cs
@@ -14,7 +14,7 @@ namespace PerfTestHarness
         {
             var iterations = Enumerable.Range(1, 500000);
             var endpoint = EndpointParser.MakeEndPointSource("localhost", 3128, null);
-            var client = new StatsDUdpTransport(endpoint);
+            var client = new UdpTransport(endpoint);
             var formatter = new StatsDMessageFormatter(CultureInfo.InvariantCulture);
             var watch = new Stopwatch();
 


### PR DESCRIPTION
Review the UDP transport
Remove the `System.Diagnostics.CodeAnalysis` thing, we don't use it.
Rename - Remove redundant "Statsd" in the name `JustEat.StatsD.StatsDUdpTransport`.  What else could it transport?