### PR TITLE
remove dependency on newtonsoft.Json

### DIFF
--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -6,9 +6,6 @@
     <RootNamespace>JustEat.StatsD</RootNamespace>
     <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.2" />
     <Reference Include="System" />


### PR DESCRIPTION
For once, I don't think that it's used at all.
I was going to update it but rather remove it, if we can.