### PR TITLE
Remove junk serialisation attr

### DIFF
--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -5,9 +5,6 @@ using System.Text;
 
 namespace JustEat.StatsD
 {
-#if NET45
-    [Serializable]
-#endif
     public class StatsDMessageFormatter
     {
         private const double DefaultSampleRate = 1.0;


### PR DESCRIPTION
Remove a junk attribute.

- the `StatsDMessageFormatter` never needs to be serialized anyway, it is behaviour not data.

- because the lib is compiled for `netstandard1.6` and `net451`, it looks to me like the `#if NET45`  is actually never true. You can put any text in that block and it still builds fine, twice over.  `#if` is pretty tricksy.