### PR TITLE
Update to .NET Core SDK 1.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 env:
   global:
-    - CLI_VERSION=1.0.1
+    - CLI_VERSION=1.0.4
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
     - NUGET_XMLDOC_MODE=skip
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath  = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile  = Join-Path $solutionPath "JustEat.StatsD.sln"
-$dotnetVersion = "1.0.1"
+$dotnetVersion = "1.0.4"
 
 if ($OutputPath -eq "") {
     $OutputPath = "$(Convert-Path "$PSScriptRoot")\artifacts"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,8 @@
 os: Visual Studio 2017
 version: 2.0.0.{build}
 configuration: Release
-assembly_info:
-  patch: true
-  file: '**\*AssemblyInfo.*'
-  assembly_version: 1.1.1
-  assembly_file_version: '{version}'
-  assembly_informational_version: '{version}'
 environment:
-  CLI_VERSION: 1.0.1
+  CLI_VERSION: 1.0.4
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 build_script:


### PR DESCRIPTION
  * Update to version `1.0.4` of the .NET Core SDK.
  * Remove redundant `assembly_info` config from `appveyor.yml`.