### PR TITLE
Remove Trace.Information() calls

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceRoot}/src/JustEat.StatsD.Tests/bin/Debug/netcoreapp1.0/JustEat.StatsD.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceRoot}/src/JustEat.StatsD.Tests",
+            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args": [
+                "${workspaceRoot}/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj"
+            ],
+            "isBuildCommand": true,
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/JustEat.StatsD/IpTransport.cs
+++ b/src/JustEat.StatsD/IpTransport.cs
@@ -35,7 +35,10 @@ namespace JustEat.StatsD
                     }
                 }
 
+#if DEBUG
                 Trace.TraceInformation("statsd: {0}", string.Join(",", metrics));
+#endif
+
                 return true;
             }
             //fire and forget, so just eat intermittent failures / exceptions

--- a/src/JustEat.StatsD/IpTransport.cs
+++ b/src/JustEat.StatsD/IpTransport.cs
@@ -35,10 +35,6 @@ namespace JustEat.StatsD
                     }
                 }
 
-#if DEBUG
-                Trace.TraceInformation("statsd: {0}", string.Join(",", metrics));
-#endif
-
                 return true;
             }
             //fire and forget, so just eat intermittent failures / exceptions

--- a/src/JustEat.StatsD/UdpTransport.cs
+++ b/src/JustEat.StatsD/UdpTransport.cs
@@ -47,7 +47,9 @@ namespace JustEat.StatsD
                     udpClient.Client.SendPacketsAsync(data);
                 }
 
+#if DEBUG
                 Trace.TraceInformation("statsd: {0}", string.Join(",", metrics));
+#endif
 
                 return true;
             }

--- a/src/JustEat.StatsD/UdpTransport.cs
+++ b/src/JustEat.StatsD/UdpTransport.cs
@@ -47,10 +47,6 @@ namespace JustEat.StatsD
                     udpClient.Client.SendPacketsAsync(data);
                 }
 
-#if DEBUG
-                Trace.TraceInformation("statsd: {0}", string.Join(",", metrics));
-#endif
-
                 return true;
             }
             //fire and forget, so just eat intermittent failures / exceptions


### PR DESCRIPTION
There have been complaints that StatsD is too noisy to the trace stream in debuggers.

In the short term, address this by only doing these calls in DEBUG. In the long term, we should log to an abstraction so consumers can control this.

`Trace.Debug()` would have been nicer, but alas, it does not exist.