### PR TITLE
Fix UdpTransport on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: required
 dist: trusty
 
+os:
+  - linux
+  - osx
+
 env:
   global:
     - CLI_VERSION=2.1.4

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -11,7 +11,7 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/src/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
+++ b/src/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using Shouldly;
+using Xunit;
+
+namespace JustEat.StatsD
+{
+    public static class WhenUsingUdpTransport
+    {
+        [Fact]
+        public static void AMetricCanBeSentWithoutAnExceptionBeingThrown()
+        {
+            // Arrange
+            var endPointSource = EndpointLookups.EndpointParser.MakeEndPointSource("127.0.0.1", 8125, null);
+            var target = new UdpTransport(endPointSource);
+
+            // Act and Assert
+            target.Send("mycustommetric");
+        }
+    }
+}

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -1,7 +1,4 @@
 using System;
-#if !NET451
-using System.Runtime.InteropServices;
-#endif
 using JustEat.StatsD.EndpointLookups;
 
 namespace JustEat.StatsD
@@ -44,7 +41,7 @@ namespace JustEat.StatsD
 
             var endpointSource = EndpointParser.MakeEndPointSource(
                 configuration.Host, configuration.Port, configuration.DnsLookupInterval);
-            _transport = CreateTransport(endpointSource);
+            _transport = new UdpTransport(endpointSource);
             _onError = configuration.OnError;
         }
 
@@ -111,23 +108,6 @@ namespace JustEat.StatsD
         public void MarkEvent(string name)
         {
             Send(_formatter.Event(name));
-        }
-
-        private static IStatsDTransport CreateTransport(IPEndPointSource endpointSource)
-        {
-#if !NET451
-            // UdpClient is not supported on Linux/macOS
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return new UdpTransport(endpointSource);
-            }
-            else
-            {
-                return new IpTransport(endpointSource);
-            }
-#else
-            return new UdpTransport(endpointSource);
-#endif
         }
 
         private void Send(string metric)

--- a/src/JustEat.StatsD/UdpTransport.cs
+++ b/src/JustEat.StatsD/UdpTransport.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
+#if !NET451
+using System.Runtime.InteropServices;
+#endif
 using JustEat.StatsD.EndpointLookups;
 
 namespace JustEat.StatsD
@@ -46,10 +49,19 @@ namespace JustEat.StatsD
 
         public UdpClient GetUdpClient()
         {
-            return new UdpClient
+            var client = new UdpClient();
+
+#if !NET451
+            // See https://github.com/dotnet/corefx/pull/17853#issuecomment-291371266
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                Client = { SendBufferSize = 0 }
-            };
+                client.Client.SendBufferSize = 0;
+            }
+#else
+            client.Client.SendBufferSize = 0;
+#endif
+
+            return client;
         }
     }
 }


### PR DESCRIPTION
To start with, this PR just adds a test that sending a metric does not throw an exception. Once Travis CI enable macOS parallel builds for us, this test should fail.

After that, we can apply the suggested fix and verify.

Relates to #42.