### PR TITLE
Fix links to CONTRIBUTING

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ The idea of "disposable timers" for using statements is an old one, see for exam
 
 ### How to contribute
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ### How to release
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -161,4 +161,4 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ### How to release
 
-See [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md#releases).


### PR DESCRIPTION
Fix links to the `CONTRIBUTING` file in the `README` caused by #47.
