### PR TITLE
Service registration extensions

### DIFF
--- a/JustEat.StatsD.Common.props
+++ b/JustEat.StatsD.Common.props
@@ -15,7 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2017
-version: 2.0.1.{build}
+version: 2.1.0.{build}
 configuration: Release
 environment:
   CLI_VERSION: 2.1.4

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -11,6 +11,7 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="Shouldly" Version="3.0.0" />

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -11,7 +11,7 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="Shouldly" Version="3.0.0" />

--- a/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
+++ b/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
@@ -1,0 +1,318 @@
+#if !NET451
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace JustEat.StatsD
+{
+    public static class WhenRegisteringStatsD
+    {
+        [Fact]
+        public static void CanRegisterServicesWithNoConfiguratonIfConfigurationAlreadRegistered()
+        {
+            // Arrange
+            var config = new StatsDConfiguration()
+            {
+                Host = "localhost"
+            };
+
+            var provider = Configure(
+                (services) =>
+                {
+                    services.AddSingleton(config);
+
+                    // Act
+                    services.AddStatsD();
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldNotBeNull();
+            configuration.ShouldBe(config);
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldNotBeNull();
+            transport.ShouldBeOfType<UdpTransport>();
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldNotBeNull();
+            publisher.ShouldBeOfType<StatsDPublisher>();
+        }
+
+        [Fact]
+        public static void CanRegisterServicesWithAHost()
+        {
+            // Arrange
+            string host = "localhost";
+
+            var provider = Configure(
+                (services) =>
+                {
+                    // Act
+                    services.AddStatsD(host);
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldNotBeNull();
+            configuration.Host.ShouldBe(host);
+            configuration.Prefix.ShouldBeEmpty();
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldNotBeNull();
+            transport.ShouldBeOfType<UdpTransport>();
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldNotBeNull();
+            publisher.ShouldBeOfType<StatsDPublisher>();
+        }
+
+        [Fact]
+        public static void CanRegisterServicesWithAHostAndPrefix()
+        {
+            // Arrange
+            string host = "localhost";
+            string prefix = "myprefix";
+
+            var provider = Configure(
+                (services) =>
+                {
+                    // Act
+                    services.AddStatsD(host, prefix);
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldNotBeNull();
+            configuration.Host.ShouldBe(host);
+            configuration.Prefix.ShouldBe(prefix);
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldNotBeNull();
+            transport.ShouldBeOfType<UdpTransport>();
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldNotBeNull();
+            publisher.ShouldBeOfType<StatsDPublisher>();
+        }
+
+        [Fact]
+        public static void CanRegisterServicesWithConfigurationObject()
+        {
+            // Arrange
+            var config = new StatsDConfiguration()
+            {
+                Host = "localhost"
+            };
+
+            var provider = Configure(
+                (services) =>
+                {
+                    // Act
+                    services.AddStatsD(config);
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldBe(config);
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldNotBeNull();
+            transport.ShouldBeOfType<UdpTransport>();
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldNotBeNull();
+            publisher.ShouldBeOfType<StatsDPublisher>();
+        }
+
+        [Fact]
+        public static void CanRegisterServicesWithConfigurationAction()
+        {
+            // Arrange
+            var provider = Configure(
+                (services) =>
+                {
+                    // Act
+                    services.AddStatsD((config) => config.Host = "localhost");
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldNotBeNull();
+            configuration.Host.ShouldBe("localhost");
+            configuration.Prefix.ShouldBeEmpty();
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldNotBeNull();
+            transport.ShouldBeOfType<UdpTransport>();
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldNotBeNull();
+            publisher.ShouldBeOfType<StatsDPublisher>();
+        }
+
+        [Fact]
+        public static void CanRegisterServicesWithConfigurationActionWithServiceProvider()
+        {
+            // Arrange
+            var options = new MyOptions()
+            {
+                StatsDHost = "localhost"
+            };
+
+            var provider = Configure(
+                (services) =>
+                {
+                    services.AddSingleton(options);
+
+                    // Act
+                    services.AddStatsD(
+                        (serviceProvider, config) =>
+                        {
+                            var myOptions = serviceProvider.GetRequiredService<MyOptions>();
+
+                            config.Host = myOptions.StatsDHost;
+                        });
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldNotBeNull();
+            configuration.Host.ShouldBe(options.StatsDHost);
+            configuration.Prefix.ShouldBeEmpty();
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldNotBeNull();
+            transport.ShouldBeOfType<UdpTransport>();
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldNotBeNull();
+            publisher.ShouldBeOfType<StatsDPublisher>();
+        }
+
+        [Fact]
+        public static void CanRegisterServicesWithFactoryMethod()
+        {
+            // Arrange
+            var options = new MyOptions()
+            {
+                StatsDHost = "localhost"
+            };
+
+            var provider = Configure(
+                (services) =>
+                {
+                    services.AddSingleton(options);
+
+                    // Act
+                    services.AddStatsD(
+                        (serviceProvider) =>
+                        {
+                            var myOptions = serviceProvider.GetRequiredService<MyOptions>();
+
+                            return new StatsDConfiguration()
+                            {
+                                Host = myOptions.StatsDHost
+                            };
+                        });
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldNotBeNull();
+            configuration.Host.ShouldBe(options.StatsDHost);
+            configuration.Prefix.ShouldBeEmpty();
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldNotBeNull();
+            transport.ShouldBeOfType<UdpTransport>();
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldNotBeNull();
+            publisher.ShouldBeOfType<StatsDPublisher>();
+        }
+
+        [Fact]
+        public static void RegisteringServicesDoesNotOverwriteExistingRegistrations()
+        {
+            // Arrange
+            var existingConfig = new StatsDConfiguration();
+            var existingTransport = Mock.Of<IStatsDTransport>();
+            var existingPublisher = Mock.Of<IStatsDPublisher>();
+
+            var provider = Configure(
+                (services) =>
+                {
+                    services.AddSingleton(existingConfig);
+                    services.AddSingleton(existingTransport);
+                    services.AddSingleton(existingPublisher);
+
+                    // Act
+                    services.AddStatsD();
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldBe(existingConfig);
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldBe(existingTransport);
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldBe(existingPublisher);
+        }
+
+        [Fact]
+        public static void CanRegisterServicesWithoutFirstConfiguringTheHost()
+        {
+            // Act and Assert
+            Should.NotThrow(() => Configure((services) => services.AddStatsD()));
+        }
+
+        [Fact]
+        public static void ParametersAreCheckedForNull()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+            StatsDConfiguration configuration = null;
+            Action<StatsDConfiguration> configure = null;
+            Action<IServiceProvider, StatsDConfiguration> configureWithProvider = null;
+            Func<IServiceProvider, StatsDConfiguration> configurationFactory = null;
+            string host = null;
+
+            // Act and Assert
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configuration)).ParamName.ShouldBe("configuration");
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configure)).ParamName.ShouldBe("configure");
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configureWithProvider)).ParamName.ShouldBe("configure");
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configurationFactory)).ParamName.ShouldBe("configurationFactory");
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(host)).ParamName.ShouldBe("host");
+
+            // Arrange
+            services = null;
+
+            // Act and Assert
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configuration)).ParamName.ShouldBe("services");
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configure)).ParamName.ShouldBe("services");
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configureWithProvider)).ParamName.ShouldBe("services");
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configurationFactory)).ParamName.ShouldBe("services");
+            Should.Throw<ArgumentNullException>(() => services.AddStatsD(host)).ParamName.ShouldBe("services");
+        }
+
+        private static IServiceProvider Configure(Action<IServiceCollection> registration)
+        {
+            var services = new ServiceCollection();
+
+            registration(services);
+
+            return services.BuildServiceProvider();
+        }
+
+        private sealed class MyOptions
+        {
+            public string StatsDHost { get; set; }
+        }
+    }
+}
+#endif

--- a/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
+++ b/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
@@ -110,109 +110,6 @@ namespace JustEat.StatsD
         }
 
         [Fact]
-        public static void CanRegisterServicesWithConfigurationObject()
-        {
-            // Arrange
-            var config = new StatsDConfiguration()
-            {
-                Host = "localhost"
-            };
-
-            var provider = Configure(
-                (services) =>
-                {
-                    // Act
-                    services.AddStatsD(config);
-                });
-
-            // Assert
-            var configuration = provider.GetRequiredService<StatsDConfiguration>();
-            configuration.ShouldBe(config);
-
-            var source = provider.GetRequiredService<IPEndPointSource>();
-            source.ShouldNotBeNull();
-
-            var transport = provider.GetRequiredService<IStatsDTransport>();
-            transport.ShouldNotBeNull();
-            transport.ShouldBeOfType<UdpTransport>();
-
-            var publisher = provider.GetRequiredService<IStatsDPublisher>();
-            publisher.ShouldNotBeNull();
-            publisher.ShouldBeOfType<StatsDPublisher>();
-        }
-
-        [Fact]
-        public static void CanRegisterServicesWithConfigurationAction()
-        {
-            // Arrange
-            var provider = Configure(
-                (services) =>
-                {
-                    // Act
-                    services.AddStatsD((config) => config.Host = "localhost");
-                });
-
-            // Assert
-            var configuration = provider.GetRequiredService<StatsDConfiguration>();
-            configuration.ShouldNotBeNull();
-            configuration.Host.ShouldBe("localhost");
-            configuration.Prefix.ShouldBeEmpty();
-
-            var source = provider.GetRequiredService<IPEndPointSource>();
-            source.ShouldNotBeNull();
-
-            var transport = provider.GetRequiredService<IStatsDTransport>();
-            transport.ShouldNotBeNull();
-            transport.ShouldBeOfType<UdpTransport>();
-
-            var publisher = provider.GetRequiredService<IStatsDPublisher>();
-            publisher.ShouldNotBeNull();
-            publisher.ShouldBeOfType<StatsDPublisher>();
-        }
-
-        [Fact]
-        public static void CanRegisterServicesWithConfigurationActionWithServiceProvider()
-        {
-            // Arrange
-            var options = new MyOptions()
-            {
-                StatsDHost = "localhost"
-            };
-
-            var provider = Configure(
-                (services) =>
-                {
-                    services.AddSingleton(options);
-
-                    // Act
-                    services.AddStatsD(
-                        (serviceProvider, config) =>
-                        {
-                            var myOptions = serviceProvider.GetRequiredService<MyOptions>();
-
-                            config.Host = myOptions.StatsDHost;
-                        });
-                });
-
-            // Assert
-            var configuration = provider.GetRequiredService<StatsDConfiguration>();
-            configuration.ShouldNotBeNull();
-            configuration.Host.ShouldBe(options.StatsDHost);
-            configuration.Prefix.ShouldBeEmpty();
-
-            var source = provider.GetRequiredService<IPEndPointSource>();
-            source.ShouldNotBeNull();
-
-            var transport = provider.GetRequiredService<IStatsDTransport>();
-            transport.ShouldNotBeNull();
-            transport.ShouldBeOfType<UdpTransport>();
-
-            var publisher = provider.GetRequiredService<IStatsDPublisher>();
-            publisher.ShouldNotBeNull();
-            publisher.ShouldBeOfType<StatsDPublisher>();
-        }
-
-        [Fact]
         public static void CanRegisterServicesWithFactoryMethod()
         {
             // Arrange
@@ -304,16 +201,10 @@ namespace JustEat.StatsD
         {
             // Arrange
             IServiceCollection services = new ServiceCollection();
-            StatsDConfiguration configuration = null;
-            Action<StatsDConfiguration> configure = null;
-            Action<IServiceProvider, StatsDConfiguration> configureWithProvider = null;
             Func<IServiceProvider, StatsDConfiguration> configurationFactory = null;
             string host = null;
 
             // Act and Assert
-            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configuration)).ParamName.ShouldBe("configuration");
-            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configure)).ParamName.ShouldBe("configure");
-            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configureWithProvider)).ParamName.ShouldBe("configure");
             Should.Throw<ArgumentNullException>(() => services.AddStatsD(configurationFactory)).ParamName.ShouldBe("configurationFactory");
             Should.Throw<ArgumentNullException>(() => services.AddStatsD(host)).ParamName.ShouldBe("host");
 
@@ -321,9 +212,6 @@ namespace JustEat.StatsD
             services = null;
 
             // Act and Assert
-            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configuration)).ParamName.ShouldBe("services");
-            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configure)).ParamName.ShouldBe("services");
-            Should.Throw<ArgumentNullException>(() => services.AddStatsD(configureWithProvider)).ParamName.ShouldBe("services");
             Should.Throw<ArgumentNullException>(() => services.AddStatsD(configurationFactory)).ParamName.ShouldBe("services");
             Should.Throw<ArgumentNullException>(() => services.AddStatsD(host)).ParamName.ShouldBe("services");
         }

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -14,6 +14,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />

--- a/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
+++ b/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
@@ -186,10 +186,21 @@ namespace JustEat.StatsD
 
         private static IServiceCollection AddStatsDCore(this IServiceCollection services)
         {
+            services.TryAddSingleton(ResolveEndPointSource);
             services.TryAddSingleton(ResolveStatsDTransport);
             services.TryAddSingleton(ResolveStatsDPublisher);
 
             return services;
+        }
+
+        private static IPEndPointSource ResolveEndPointSource(IServiceProvider provider)
+        {
+            var config = provider.GetRequiredService<StatsDConfiguration>();
+
+            return EndpointParser.MakeEndPointSource(
+                config.Host,
+                config.Port,
+                config.DnsLookupInterval);
         }
 
         private static IStatsDPublisher ResolveStatsDPublisher(IServiceProvider provider)
@@ -202,13 +213,7 @@ namespace JustEat.StatsD
 
         private static IStatsDTransport ResolveStatsDTransport(IServiceProvider provider)
         {
-            var config = provider.GetRequiredService<StatsDConfiguration>();
-
-            var endpointSource = EndpointParser.MakeEndPointSource(
-                config.Host,
-                config.Port,
-                config.DnsLookupInterval);
-
+            var endpointSource = provider.GetRequiredService<IPEndPointSource>();
             return new UdpTransport(endpointSource);
         }
     }

--- a/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
+++ b/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
@@ -1,0 +1,216 @@
+#if !NET451
+using System;
+using JustEat.StatsD.EndpointLookups;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace JustEat.StatsD
+{
+    /// <summary>
+    /// A class containing extension methods for registering statsD services with <see cref="IServiceCollection"/>. This class cannot be inherited.
+    /// </summary>
+    public static class StatsDServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds statsD services to the specified <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The service collection to register statsD with.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddStatsD(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.AddStatsDCore();
+            services.TryAddSingleton<StatsDConfiguration>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds statsD services to the specified <see cref="IServiceCollection"/> for the specified host and optional prefix.
+        /// </summary>
+        /// <param name="services">The service collection to register statsD with.</param>
+        /// <param name="host">The host name or IP address of the statsD server.</param>
+        /// <param name="prefix">An optional prefix to prepend to all stats.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> or <paramref name="host"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddStatsD(this IServiceCollection services, string host, string prefix = null)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (host == null)
+            {
+                throw new ArgumentNullException(nameof(host));
+            }
+
+            return services.AddStatsD(
+                (configuration) =>
+                {
+                    configuration.Host = host;
+                    configuration.Prefix = prefix ?? string.Empty;
+                });
+        }
+
+        /// <summary>
+        /// Adds statsD services to the specified <see cref="IServiceCollection"/> with the specified configuration.
+        /// </summary>
+        /// <param name="services">The service collection to register statsD with.</param>
+        /// <param name="configuration">The statsD configuration to use.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> or <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddStatsD(this IServiceCollection services, StatsDConfiguration configuration)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            services.AddStatsDCore();
+            services.AddSingleton(configuration);
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds StatsD services to the specified <see cref="IServiceCollection"/> with the specified configuration delegate.
+        /// </summary>
+        /// <param name="services">The service collection to register StatsD with.</param>
+        /// <param name="configure">A delegate to a method to use to configure the StatsD configuration.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddStatsD(this IServiceCollection services, Action<StatsDConfiguration> configure)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return services.AddStatsD((_, configuration) => configure(configuration));
+        }
+
+        /// <summary>
+        /// Adds statsD services to the specified <see cref="IServiceCollection"/> with the specified configuration delegate.
+        /// </summary>
+        /// <param name="services">The service collection to register statsD with.</param>
+        /// <param name="configure">A delegate to a method to use to configure the statsD configuration.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddStatsD(this IServiceCollection services, Action<IServiceProvider, StatsDConfiguration> configure)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            return services.AddStatsD(
+                (provider) =>
+                {
+                    var configuration = new StatsDConfiguration();
+
+                    configure(provider, configuration);
+
+                    return configuration;
+                });
+        }
+
+        /// <summary>
+        /// Adds statsD services to the specified <see cref="IServiceCollection"/> using the specified delegate to create the configuration.
+        /// </summary>
+        /// <param name="services">The service collection to register statsD with.</param>
+        /// <param name="configurationFactory">A delegate to a method to use to create the statsD configuration.</param>
+        /// <returns>
+        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="services"/> or <paramref name="configurationFactory"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddStatsD(this IServiceCollection services, Func<IServiceProvider, StatsDConfiguration> configurationFactory)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (configurationFactory == null)
+            {
+                throw new ArgumentNullException(nameof(configurationFactory));
+            }
+
+            services.AddStatsDCore();
+            services.AddSingleton(configurationFactory);
+
+            return services;
+        }
+
+        private static IServiceCollection AddStatsDCore(this IServiceCollection services)
+        {
+            services.TryAddSingleton(ResolveStatsDTransport);
+            services.TryAddSingleton(ResolveStatsDPublisher);
+
+            return services;
+        }
+
+        private static IStatsDPublisher ResolveStatsDPublisher(IServiceProvider provider)
+        {
+            var config = provider.GetRequiredService<StatsDConfiguration>();
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+
+            return new StatsDPublisher(config, transport);
+        }
+
+        private static IStatsDTransport ResolveStatsDTransport(IServiceProvider provider)
+        {
+            var config = provider.GetRequiredService<StatsDConfiguration>();
+
+            var endpointSource = EndpointParser.MakeEndPointSource(
+                config.Host,
+                config.Port,
+                config.DnsLookupInterval);
+
+            return new UdpTransport(endpointSource);
+        }
+    }
+}
+#endif

--- a/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
+++ b/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
@@ -59,99 +59,13 @@ namespace JustEat.StatsD
             }
 
             return services.AddStatsD(
-                (configuration) =>
+                (_) =>
                 {
-                    configuration.Host = host;
-                    configuration.Prefix = prefix ?? string.Empty;
-                });
-        }
-
-        /// <summary>
-        /// Adds statsD services to the specified <see cref="IServiceCollection"/> with the specified configuration.
-        /// </summary>
-        /// <param name="services">The service collection to register statsD with.</param>
-        /// <param name="configuration">The statsD configuration to use.</param>
-        /// <returns>
-        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="services"/> or <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        public static IServiceCollection AddStatsD(this IServiceCollection services, StatsDConfiguration configuration)
-        {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
-
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            services.AddStatsDCore();
-            services.AddSingleton(configuration);
-
-            return services;
-        }
-
-        /// <summary>
-        /// Adds StatsD services to the specified <see cref="IServiceCollection"/> with the specified configuration delegate.
-        /// </summary>
-        /// <param name="services">The service collection to register StatsD with.</param>
-        /// <param name="configure">A delegate to a method to use to configure the StatsD configuration.</param>
-        /// <returns>
-        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.
-        /// </exception>
-        public static IServiceCollection AddStatsD(this IServiceCollection services, Action<StatsDConfiguration> configure)
-        {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
-
-            if (configure == null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
-
-            return services.AddStatsD((_, configuration) => configure(configuration));
-        }
-
-        /// <summary>
-        /// Adds statsD services to the specified <see cref="IServiceCollection"/> with the specified configuration delegate.
-        /// </summary>
-        /// <param name="services">The service collection to register statsD with.</param>
-        /// <param name="configure">A delegate to a method to use to configure the statsD configuration.</param>
-        /// <returns>
-        /// The <see cref="IServiceCollection"/> specified by <paramref name="services"/>.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="services"/> or <paramref name="configure"/> is <see langword="null"/>.
-        /// </exception>
-        public static IServiceCollection AddStatsD(this IServiceCollection services, Action<IServiceProvider, StatsDConfiguration> configure)
-        {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
-
-            if (configure == null)
-            {
-                throw new ArgumentNullException(nameof(configure));
-            }
-
-            return services.AddStatsD(
-                (provider) =>
-                {
-                    var configuration = new StatsDConfiguration();
-
-                    configure(provider, configuration);
-
-                    return configuration;
+                    return new StatsDConfiguration()
+                    {
+                        Host = host,
+                        Prefix = prefix ?? string.Empty,
+                    };
                 });
         }
 


### PR DESCRIPTION
Some initial ideas on baking service registration extensions for .NET Core into the library itself to avoid the need for repetitive boilerplate in our consuming applications.

I've included several different flavours of registration method, maybe _too_ many, but we can always remove some if we think it's a bit too excessive.

Main use cases I've tried to cater for are:
  * Simple registering of the default required types, but with the step to configure the host left to the integrator to achieve by other means, such as using `Configure()` from the `Microsoft.Extensions.Configuration` package.
  * Simple registration with a string for the host name and an optional prefix.
  * Registration from a provided `StatsDConfiguration` instance.
  * Registration using a callback delegate to configure a `StatsDConfiguration` object passed to the caller, similar to `Configure()`.
  * Registration with a factory method to provide a `StatsDConfiguration` for us to use provided by the callee.
  * Variations on the above but with `IServiceProvider` as a delegate parameter so the integrator can lazily-resolve their other services  to populate/provide a `StatsDConfiguration` instance.

Use the included tests as pseudo-examples of use cases. Proper documentation can be added later after review/refinement.

For now, I've intentionally only supported this with `netstandard1.6` to avoid polluting `net451` consumers with all the extra libraries from ".NET Standard Land" full framework projects would otherwise pull in and cause a mess/bloat. We can revisit that if there's a nice way to make it available for them without introducing a tonne of additional dependencies.