### PR TITLE
Add README example and test for use with AWS Lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ services.AddStatsD(
     });
 ```
 
+#### .NET Core (AWS Lambda functions)
+
+An example of registering StatsD dependencies using `IServiceCollection` when using an AWS Lambda function:
+
+```csharp
+// Simple
+services.AddSingleton<IStatsDTransport, IpTransport>();
+services.AddStatsD(Environment.GetEnvironmentVariable("MY_STATSD_ENDPOINT"));
+
+// Advanced
+services.AddSingleton<IStatsDTransport, IpTransport>();
+services.AddStatsD(
+    (provider) =>
+    {
+        var options = provider.GetRequiredService<MyOptions>().StatsD;
+
+        return new StatsDConfiguration()
+        {
+            Host = options.HostName,
+            Port = options.Port,
+            Prefix = options.Prefix,
+            OnError = ex => LogError(ex),
+            Culture = CultureInfo.InvariantCulture,
+        };
+    });
+`
+
 #### .NET 4.5.1
 
 An example of IoC in Ninject for StatsD publisher with values for all options, read from configuration:

--- a/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
+++ b/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
@@ -249,6 +249,38 @@ namespace JustEat.StatsD
             publisher.ShouldBeOfType<StatsDPublisher>();
         }
 
+        [Fact]
+        public static void CanRegisterServicesWithIPTransport()
+        {
+            // Arrange
+            string host = "127.0.0.1";
+
+            var provider = Configure(
+                (services) =>
+                {
+                    // Act
+                    services.AddSingleton<IStatsDTransport, IpTransport>();
+                    services.AddStatsD(host);
+                });
+
+            // Assert
+            var configuration = provider.GetRequiredService<StatsDConfiguration>();
+            configuration.ShouldNotBeNull();
+            configuration.Host.ShouldBe(host);
+            configuration.Prefix.ShouldBeEmpty();
+
+            var source = provider.GetRequiredService<IPEndPointSource>();
+            source.ShouldNotBeNull();
+
+            var transport = provider.GetRequiredService<IStatsDTransport>();
+            transport.ShouldNotBeNull();
+            transport.ShouldBeOfType<IpTransport>();
+
+            var publisher = provider.GetRequiredService<IStatsDPublisher>();
+            publisher.ShouldNotBeNull();
+            publisher.ShouldBeOfType<StatsDPublisher>();
+        }
+
         private static IServiceProvider Configure(Action<IServiceCollection> registration)
         {
             var services = new ServiceCollection();


### PR DESCRIPTION
Add an example to the `README` as well as a test for registering StatsD when running code in an AWS Lambda function for the registrations added by #49.