### PR TITLE
Adding Gauge methods that support double as a parameter

### DIFF
--- a/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace JustEat.StatsD.Extensions
@@ -67,6 +67,18 @@ namespace JustEat.StatsD.Extensions
         {
             CallCount++;
             BucketNames.AddRange(buckets);
+        }
+
+        public void Gauge(double value, string bucket)
+        {
+            CallCount++;
+            BucketNames.Add(bucket);
+        }
+
+        public void Gauge(double value, string bucket, DateTime timestamp)
+        {
+            CallCount++;
+            BucketNames.Add(bucket);
         }
 
         public void Gauge(long value, string bucket)

--- a/src/JustEat.StatsD.Tests/WhenRecordingGauges.cs
+++ b/src/JustEat.StatsD.Tests/WhenRecordingGauges.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using Shouldly;
 using Xunit;
@@ -22,7 +22,40 @@ namespace JustEat.StatsD
         }
 
         [Fact]
+        public static void GaugeMetricsAreFormattedCorrectlyUsingDouble()
+        {
+            string statBucket = "gauge-bucket";
+            //generate a random double value between 0.1 and 100
+            double magnitude = new Random().NextDouble() * (100 - 0.1) + 0.1;
+
+            var culture = new CultureInfo("en-US");
+            var target = new StatsDMessageFormatter(culture);
+
+            string actual = target.Gauge(magnitude, statBucket);
+
+            actual.ShouldBe(string.Format(culture, "{0}:{1}|g", statBucket, magnitude));
+        }
+
+        [Fact]
         public static void GaugeMetricsAreFormattedCorrectlyWhenTheyContainATimestamp()
+        {
+            string statBucket = "gauge-bucket";
+            //generate a random double value between 0.1 and 100
+            double magnitude = new Random().NextDouble() * (100 - 0.1) + 0.1;
+
+            var culture = new CultureInfo("en-US");
+            var target = new StatsDMessageFormatter(culture);
+
+            var timestamp = DateTime.Now;
+
+            string actual = target.Gauge(magnitude, statBucket, timestamp);
+
+            actual.ShouldBe(string.Format(culture, "{0}:{1}|g|@{2}", statBucket, magnitude, timestamp.AsUnixTime()));
+
+        }
+
+        [Fact]
+        public static void GaugeMetricsAreFormattedCorrectlyWhenTheyContainATimestampUsingDouble()
         {
             string statBucket = "gauge-bucket";
             long magnitude = new Random().Next(100);
@@ -48,6 +81,25 @@ namespace JustEat.StatsD
             string statBucket = "gauge-bucket";
             string incompatibleValue = magnitude.ToString("0.00", culture);
             
+            var target = new StatsDMessageFormatter(culture);
+
+            string actual = target.Gauge(magnitude, statBucket);
+
+            actual.ShouldNotContain(incompatibleValue);
+            actual.ShouldBe(string.Format(culture, "{0}:{1}|g", statBucket, magnitude));
+        }
+
+        [Fact]
+        public static void GaugeMetricsAreFormattedCorrectlyIfTheCultureIsIncompatibleUsingDouble()
+        {
+            // Setup a value that will create a value where '.' and ',' have opposite meanings to US/UK English.
+            var culture = new CultureInfo("da-DK");
+            //generate a random double value between 0.1 and 100
+            double magnitude = new Random().NextDouble() * (100000000 - 0.1) + 0.1;
+
+            string statBucket = "gauge-bucket";
+            string incompatibleValue = magnitude.ToString("0.00", culture);
+
             var target = new StatsDMessageFormatter(culture);
 
             string actual = target.Gauge(magnitude, statBucket);

--- a/src/JustEat.StatsD.Tests/WhenRecordingGauges.cs
+++ b/src/JustEat.StatsD.Tests/WhenRecordingGauges.cs
@@ -98,7 +98,7 @@ namespace JustEat.StatsD
             double magnitude = new Random().NextDouble() * (100000000 - 0.1) + 0.1;
 
             string statBucket = "gauge-bucket";
-            string incompatibleValue = magnitude.ToString("0.00", culture);
+            string incompatibleValue = magnitude.ToString("0.00000000", culture);
 
             var target = new StatsDMessageFormatter(culture);
 

--- a/src/JustEat.StatsD/IStatsDPublisher.cs
+++ b/src/JustEat.StatsD/IStatsDPublisher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace JustEat.StatsD
 {
@@ -12,6 +12,8 @@ namespace JustEat.StatsD
         void Decrement(long value, string bucket);
         void Decrement(long value, double sampleRate, string bucket);
         void Decrement(long value, double sampleRate, params string[] buckets);
+        void Gauge(double value, string bucket);
+        void Gauge(double value, string bucket, DateTime timestamp);
         void Gauge(long value, string bucket);
         void Gauge(long value, string bucket, DateTime timestamp);
         void Timing(TimeSpan duration, string bucket);

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -99,6 +99,17 @@ namespace JustEat.StatsD
         public string Increment(long magnitude, double sampleRate, params string[] statBuckets)
         {
             return Format(sampleRate, statBuckets.Select(key => string.Format(_cultureInfo, "{0}{1}:{2}|c", _prefix, key, magnitude)).ToArray());
+        }
+
+        public string Gauge(double magnitude, string statBucket)
+        {
+            var stat = string.Format(_cultureInfo, "{0}{1}:{2}|g", _prefix, statBucket, magnitude);
+            return Format(stat, DefaultSampleRate);
+        }
+        public string Gauge(double magnitude, string statBucket, DateTime timestamp)
+        {
+            var stat = string.Format(_cultureInfo, "{0}{1}:{2}|g|@{3}", _prefix, statBucket, magnitude, timestamp.AsUnixTime());
+            return Format(stat, DefaultSampleRate);
         }
 
         public string Gauge(long magnitude, string statBucket)

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -84,7 +84,14 @@ namespace JustEat.StatsD
         {
             Send(_formatter.Decrement(value, sampleRate, buckets));
         }
-
+        public void Gauge(double  value, string bucket)
+        {
+            Send(_formatter.Gauge(value, bucket));
+        }
+        public void Gauge(double value, string bucket, DateTime timestamp)
+        {
+            Send(_formatter.Gauge(value, bucket, timestamp));
+        }
         public void Gauge(long value, string bucket)
         {
             Send(_formatter.Gauge(value, bucket));


### PR DESCRIPTION
Adding Gauge methods that support double as a parameter

_Summarise the changes this Pull Request makes._
Added Gauge methods in Publisher and Formatter classes that take a double as a parameter. I need to send fractional values to StatsD and a long value didn't allow me to do that.

_Please include a reference to a GitHub issue if appropriate._
