### PR TITLE
Reduce allocations

### DIFF
--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -163,7 +163,7 @@ namespace JustEat.StatsD
             {
                 foreach (var stat in stats)
                 {
-                    formatted.AppendFormat(_cultureInfo, "{0}", stat);
+                    formatted.Append(stat);
                 }
             }
 

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -131,16 +131,11 @@ namespace JustEat.StatsD
 
         private string Format(double sampleRate, string stat)
         {
-            if (sampleRate < DefaultSampleRate)
+            if (sampleRate >= DefaultSampleRate) return stat;
+
+            if (Random.NextDouble() <= sampleRate)
             {
-                if (Random.NextDouble() <= sampleRate)
-                {
-                    return string.Format(_cultureInfo, "{0}|@{1:f}", stat, sampleRate);
-                }
-            }
-            else
-            {
-                return stat;
+                return string.Format(_cultureInfo, "{0}|@{1:f}", stat, sampleRate);
             }
 
             return string.Empty;

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -140,7 +140,7 @@ namespace JustEat.StatsD
             }
             else
             {
-                return string.Format(_cultureInfo, "{0}", stat);
+                return stat;
             }
 
             return string.Empty;

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -131,7 +131,10 @@ namespace JustEat.StatsD
 
         private string Format(double sampleRate, string stat)
         {
-            if (sampleRate >= DefaultSampleRate) return stat;
+            if (sampleRate >= DefaultSampleRate)
+            {
+                return stat;
+            }
 
             if (Random.NextDouble() <= sampleRate)
             {

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -88,7 +88,7 @@ namespace JustEat.StatsD
         public string Increment(long magnitude, double sampleRate, string statBucket)
         {
             var stat = string.Format(_cultureInfo, "{0}{1}:{2}|c", _prefix, statBucket, magnitude);
-            return Format(stat, sampleRate);
+            return Format(sampleRate, stat);
         }
 
         public string Increment(long magnitude, params string[] statBuckets)
@@ -104,24 +104,24 @@ namespace JustEat.StatsD
         public string Gauge(double magnitude, string statBucket)
         {
             var stat = string.Format(_cultureInfo, "{0}{1}:{2}|g", _prefix, statBucket, magnitude);
-            return Format(stat, DefaultSampleRate);
+            return Format(DefaultSampleRate, stat);
         }
         public string Gauge(double magnitude, string statBucket, DateTime timestamp)
         {
             var stat = string.Format(_cultureInfo, "{0}{1}:{2}|g|@{3}", _prefix, statBucket, magnitude, timestamp.AsUnixTime());
-            return Format(stat, DefaultSampleRate);
+            return Format(DefaultSampleRate, stat);
         }
 
         public string Gauge(long magnitude, string statBucket)
         {
             var stat = string.Format(_cultureInfo, "{0}{1}:{2}|g", _prefix, statBucket, magnitude);
-            return Format(stat, DefaultSampleRate);
+            return Format(DefaultSampleRate, stat);
         }
 
         public string Gauge(long magnitude, string statBucket, DateTime timestamp)
         {
             var stat = string.Format(_cultureInfo, "{0}{1}:{2}|g|@{3}", _prefix, statBucket, magnitude, timestamp.AsUnixTime());
-            return Format(stat, DefaultSampleRate);
+            return Format(DefaultSampleRate, stat);
         }
 
         public string Event(string name)
@@ -129,9 +129,21 @@ namespace JustEat.StatsD
             return Increment(name);
         }
 
-        private string Format(String stat, double sampleRate)
+        private string Format(double sampleRate, string stat)
         {
-            return Format(sampleRate, stat);
+            if (sampleRate < DefaultSampleRate)
+            {
+                if (Random.NextDouble() <= sampleRate)
+                {
+                    return string.Format(_cultureInfo, "{0}|@{1:f}", stat, sampleRate);
+                }
+            }
+            else
+            {
+                return string.Format(_cultureInfo, "{0}", stat);
+            }
+
+            return string.Empty;
         }
 
         private string Format(double sampleRate, params string[] stats)


### PR DESCRIPTION
Quick win by taking out redundant `StringBuilder` for single metric case.

Before:

 Method |     Mean |     Error |    StdDev | Allocated |
------- |---------:|----------:|----------:|----------:|
 RunUdp | 646.7 us | 12.583 us | 13.985 us |   1.84 KB |
  RunIp | 608.6 us |  9.037 us |  7.546 us |   1.84 KB |

After:

 Method |     Mean |    Error |   StdDev | Allocated |
------- |---------:|---------:|---------:|----------:|
 RunUdp | 620.2 us | 12.00 us | 14.74 us |   1.37 KB |
  RunIp | 590.4 us | 11.11 us | 10.91 us |   1.37 KB |

After removing redundant `string.Format`:

 Method |     Mean |    Error |    StdDev | Allocated |
------- |---------:|---------:|----------:|----------:|
 RunUdp | 622.2 us | 12.07 us | 12.915 us |    1.2 KB |
  RunIp | 585.5 us | 10.54 us |  8.802 us |    1.2 KB |