### PR TITLE
Culture info should not be configurable

### DIFF
--- a/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
+++ b/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Shouldly;
 using Xunit;
 
@@ -39,19 +39,6 @@ namespace JustEat.StatsD
 
             Should.Throw<ArgumentNullException>(
              () => new StatsDPublisher(noConfig));
-        }
-
-        [Fact]
-        public void ConfigurationHasNoCulture()
-        {
-            var badConfig = new StatsDConfiguration
-            {
-                Host = "someserver.somewhere.com",
-                Culture = null
-            };
-
-            Should.Throw<ArgumentNullException>(
-             () => new StatsDPublisher(badConfig));
         }
 
         [Fact]

--- a/src/JustEat.StatsD.Tests/WhenRecordingCounters.cs
+++ b/src/JustEat.StatsD.Tests/WhenRecordingCounters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Text;
 using Shouldly;
@@ -11,7 +11,6 @@ namespace JustEat.StatsD
         private readonly string _statBucket;
         private readonly string[] _statBuckets;
         private readonly long _value;
-        private readonly CultureInfo _culture;
 
         public WhenRecordingCounters()
         {
@@ -19,40 +18,39 @@ namespace JustEat.StatsD
             _statBuckets = new[] { "counter-bucket-1", "counter-bucket-2" };
 
             _value = new Random().Next(1, 100);
-            _culture = new CultureInfo("en-US");
         }
 
         [Fact]
         public void DecrementingCounterIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Decrement(_statBucket);
 
             // Assert
-            actual.ShouldBe(string.Format(_culture, "{0}:-{1}|c", _statBucket, 1));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:-{1}|c", _statBucket, 1));
         }
 
         [Fact]
         public void DecrementingCounterWithValueIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Decrement(_value, _statBucket);
 
             // Assert
-            actual.ShouldBe(string.Format(_culture, "{0}:-{1}|c", _statBucket, _value));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:-{1}|c", _statBucket, _value));
         }
 
         [Fact]
         public void DecrementingMultipleCountersIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Decrement(_value, _statBuckets);
@@ -62,7 +60,7 @@ namespace JustEat.StatsD
 
             foreach (var stat in _statBuckets)
             {
-                expected.AppendFormat(_culture, "{0}:-{1}|c", stat, _value);
+                expected.AppendFormat(CultureInfo.InvariantCulture, "{0}:-{1}|c", stat, _value);
             }
 
             actual.ShouldBe(expected.ToString());
@@ -72,33 +70,33 @@ namespace JustEat.StatsD
         public void IncrementingCounterIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Increment(_statBucket);
 
             // Assert
-            actual.ShouldBe(string.Format(_culture, "{0}:{1}|c", _statBucket, 1));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|c", _statBucket, 1));
         }
 
         [Fact]
         public void IncrementingCounterWithValueIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Increment(_value, _statBucket);
 
             // Assert
-            actual.ShouldBe(string.Format(_culture, "{0}:{1}|c", _statBucket, _value));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|c", _statBucket, _value));
         }
 
         [Fact]
         public void IncrementingMultipleCountersIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Increment(_value, _statBuckets);
@@ -108,7 +106,7 @@ namespace JustEat.StatsD
 
             foreach (var stat in _statBuckets)
             {
-                expected.AppendFormat(_culture, "{0}:{1}|c", stat, _value);
+                expected.AppendFormat(CultureInfo.InvariantCulture, "{0}:{1}|c", stat, _value);
             }
 
             actual.ShouldBe(expected.ToString());
@@ -118,7 +116,7 @@ namespace JustEat.StatsD
         public void RaisingEventIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Event("foo");
@@ -131,33 +129,33 @@ namespace JustEat.StatsD
         public void GaugeIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Gauge(_value, _statBucket);
 
             // Assert
-            actual.ShouldBe(string.Format(_culture, "{0}:{1}|g", _statBucket, _value));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|g", _statBucket, _value));
         }
 
         [Fact]
         public void TimingIsCorrect()
         {
             // Arrange
-            var target = new StatsDMessageFormatter(_culture);
+            var target = new StatsDMessageFormatter();
 
             // Act
             string actual = target.Timing(_value, _statBucket);
 
             // Assert
-            actual.ShouldBe(string.Format(_culture, "{0}:{1}|ms", _statBucket, _value));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|ms", _statBucket, _value));
         }
 
         [Fact]
         public void ValuesArePrefixed()
         {
             var prefix = "foo";
-            var target = new StatsDMessageFormatter(_culture, prefix);
+            var target = new StatsDMessageFormatter(prefix);
 
             var actualGauge = target.Gauge(_value, _statBucket);
             var actualDecrement = target.Decrement(_statBucket);

--- a/src/JustEat.StatsD.Tests/WhenRecordingGauges.cs
+++ b/src/JustEat.StatsD.Tests/WhenRecordingGauges.cs
@@ -13,12 +13,11 @@ namespace JustEat.StatsD
             string statBucket = "gauge-bucket";
             long magnitude = new Random().Next(100);
 
-            var culture = new CultureInfo("en-US");
-            var target = new StatsDMessageFormatter(culture);
+            var target = new StatsDMessageFormatter();
 
             string actual = target.Gauge(magnitude, statBucket);
 
-            actual.ShouldBe(string.Format(culture, "{0}:{1}|g", statBucket, magnitude));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|g", statBucket, magnitude));
         }
 
         [Fact]
@@ -28,12 +27,11 @@ namespace JustEat.StatsD
             //generate a random double value between 0.1 and 100
             double magnitude = new Random().NextDouble() * (100 - 0.1) + 0.1;
 
-            var culture = new CultureInfo("en-US");
-            var target = new StatsDMessageFormatter(culture);
+            var target = new StatsDMessageFormatter();
 
             string actual = target.Gauge(magnitude, statBucket);
 
-            actual.ShouldBe(string.Format(culture, "{0}:{1}|g", statBucket, magnitude));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|g", statBucket, magnitude));
         }
 
         [Fact]
@@ -43,14 +41,13 @@ namespace JustEat.StatsD
             //generate a random double value between 0.1 and 100
             double magnitude = new Random().NextDouble() * (100 - 0.1) + 0.1;
 
-            var culture = new CultureInfo("en-US");
-            var target = new StatsDMessageFormatter(culture);
+            var target = new StatsDMessageFormatter();
 
             var timestamp = DateTime.Now;
 
             string actual = target.Gauge(magnitude, statBucket, timestamp);
 
-            actual.ShouldBe(string.Format(culture, "{0}:{1}|g|@{2}", statBucket, magnitude, timestamp.AsUnixTime()));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|g|@{2}", statBucket, magnitude, timestamp.AsUnixTime()));
 
         }
 
@@ -60,52 +57,14 @@ namespace JustEat.StatsD
             string statBucket = "gauge-bucket";
             long magnitude = new Random().Next(100);
 
-            var culture = new CultureInfo("en-US");
-            var target = new StatsDMessageFormatter(culture);
+            var target = new StatsDMessageFormatter();
 
             var timestamp = DateTime.Now;
 
             string actual = target.Gauge(magnitude, statBucket, timestamp);
 
-            actual.ShouldBe(string.Format(culture, "{0}:{1}|g|@{2}", statBucket, magnitude, timestamp.AsUnixTime()));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|g|@{2}", statBucket, magnitude, timestamp.AsUnixTime()));
 
-        }
-
-        [Fact]
-        public static void GaugeMetricsAreFormattedCorrectlyIfTheCultureIsIncompatible()
-        {
-            // Setup a value that will create a value where '.' and ',' have opposite meanings to US/UK English.
-            var culture = new CultureInfo("da-DK");
-            long magnitude = 100000000;
-
-            string statBucket = "gauge-bucket";
-            string incompatibleValue = magnitude.ToString("0.00", culture);
-            
-            var target = new StatsDMessageFormatter(culture);
-
-            string actual = target.Gauge(magnitude, statBucket);
-
-            actual.ShouldNotContain(incompatibleValue);
-            actual.ShouldBe(string.Format(culture, "{0}:{1}|g", statBucket, magnitude));
-        }
-
-        [Fact]
-        public static void GaugeMetricsAreFormattedCorrectlyIfTheCultureIsIncompatibleUsingDouble()
-        {
-            // Setup a value that will create a value where '.' and ',' have opposite meanings to US/UK English.
-            var culture = new CultureInfo("da-DK");
-            //generate a random double value between 0.1 and 100
-            double magnitude = new Random().NextDouble() * (100000000 - 0.1) + 0.1;
-
-            string statBucket = "gauge-bucket";
-            string incompatibleValue = magnitude.ToString("0.00000000", culture);
-
-            var target = new StatsDMessageFormatter(culture);
-
-            string actual = target.Gauge(magnitude, statBucket);
-
-            actual.ShouldNotContain(incompatibleValue);
-            actual.ShouldBe(string.Format(culture, "{0}:{1}|g", statBucket, magnitude));
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/WhenRecordingTimers.cs
+++ b/src/JustEat.StatsD.Tests/WhenRecordingTimers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using Shouldly;
 using Xunit;
@@ -13,12 +13,11 @@ namespace JustEat.StatsD
             string statBucket = "timing-bucket";
             long milliseconds = new Random().Next(1000);
 
-            var culture = new CultureInfo("en-US");
-            var target = new StatsDMessageFormatter(culture);
+            var target = new StatsDMessageFormatter();
 
             string actual = target.Timing(milliseconds, statBucket);
 
-            actual.ShouldBe(string.Format(culture, "{0}:{1:d}|ms", statBucket, milliseconds));
+            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1:d}|ms", statBucket, milliseconds));
         }
     }
 }

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -34,12 +34,6 @@ namespace JustEat.StatsD
         public string Prefix { get; set; } = string.Empty;
 
         /// <summary>
-        /// Culture for formatting stats.
-        /// Default is InvariantCulture.
-        /// </summary>
-        public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
-
-        /// <summary>
         /// Function to receive notification of any exceptions
         /// This function should return:
         /// True if the exception was handled and no further action is needed

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -12,15 +12,14 @@ namespace JustEat.StatsD
         [ThreadStatic]
         private static Random _random;
 
-        private readonly CultureInfo _cultureInfo;
+        private readonly CultureInfo _cultureInfo = CultureInfo.InvariantCulture;
         private readonly string _prefix;
 
-        public StatsDMessageFormatter(CultureInfo cultureInfo)
-            : this(cultureInfo, string.Empty) {}
+        public StatsDMessageFormatter()
+            : this(string.Empty) {}
 
-            public StatsDMessageFormatter(CultureInfo cultureInfo, string prefix)
+            public StatsDMessageFormatter(string prefix)
         {
-            _cultureInfo = cultureInfo ?? throw new ArgumentNullException(nameof(cultureInfo));
             _prefix = prefix;
 
             if (!string.IsNullOrWhiteSpace(_prefix))

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -21,7 +21,7 @@ namespace JustEat.StatsD
 
             _transport = transport ?? throw new ArgumentNullException(nameof(transport));
 
-            _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
+            _formatter = new StatsDMessageFormatter(configuration.Prefix);
             _onError = configuration.OnError;
         }
 
@@ -37,7 +37,7 @@ namespace JustEat.StatsD
                 throw new ArgumentNullException(nameof(configuration.Host));
             }
 
-            _formatter = new StatsDMessageFormatter(configuration.Culture, configuration.Prefix);
+            _formatter = new StatsDMessageFormatter(configuration.Prefix);
 
             var endpointSource = EndpointParser.MakeEndPointSource(
                 configuration.Host, configuration.Port, configuration.DnsLookupInterval);


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Simplify. We always want to use `CultureInfo.InvariantCulture` in the formatter. Do not allow this to be user configurable via the settings object.

_Please include a reference to a GitHub issue if appropriate._

#56 