### PR TITLE
fast path, no number formats

### DIFF
--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -86,6 +86,11 @@ namespace JustEat.StatsD
 
         public string Increment(long magnitude, double sampleRate, string statBucket)
         {
+            if (magnitude == 1 && sampleRate == 1.0)
+            {
+                return _prefix + statBucket + ":1|c";
+            }
+
             var stat = string.Format(InvariantCulture, "{0}{1}:{2}|c", _prefix, statBucket, magnitude);
             return Format(sampleRate, stat);
         }


### PR DESCRIPTION
Fast path for the common case of "increment by 1" with no number formatting

Before

  Method |     Mean |    Error |    StdDev |  Gen 0 | Allocated |
------------ |---------:|---------:|----------:|-------:|----------:|
 Increment12 | 241.2 ns | 2.622 ns | 2.3240 ns | 0.0429 |     136 B |
  Increment1 | 238.9 ns | 1.213 ns | 0.8771 ns | 0.0429 |     136 B |
  
After

   Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
------------ |----------:|----------:|----------:|-------:|----------:|
 Increment12 | 248.46 ns | 5.6065 ns | 5.9989 ns | 0.0429 |     136 B |
  Increment1 |  34.69 ns | 0.1578 ns | 0.1399 ns | 0.0254 |      80 B |
