### PR TITLE
fewer string formats

### DIFF
--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -37,7 +37,8 @@ namespace JustEat.StatsD
 
         public string Timing(long milliseconds, double sampleRate, string statBucket)
         {
-            return Format(sampleRate, string.Format(InvariantCulture, "{0}{1}:{2:d}|ms", _prefix, statBucket, milliseconds));
+            var stat = string.Concat(_prefix, statBucket, ":", milliseconds.ToString("d", InvariantCulture), "|ms");
+            return Format(sampleRate, stat);
         }
 
         public string Decrement(string statBucket)
@@ -91,7 +92,7 @@ namespace JustEat.StatsD
                 return _prefix + statBucket + ":1|c";
             }
 
-            var stat = string.Format(InvariantCulture, "{0}{1}:{2}|c", _prefix, statBucket, magnitude);
+            var stat = string.Concat(_prefix, statBucket, ":", magnitude.ToString(InvariantCulture), "|c");
             return Format(sampleRate, stat);
         }
 


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Use fewer calls to `string.Format` as this is known as the most general but slowest way to join strings.
Specifically, without it, we don't have the overhead of parsing the format string.

When we actually benchmark it, the is run faster - about 50% of before. Allocation is slightly _higher_ , I don't know why 😞. 

I also don't know why the number for `IncrementBy1` in the before case have changed a bit. They should not have. I suppose this benchmark isn't perfect?

If we decide against this change because of the extra allocations, that's fine; this PR will serve to document the desision.

Before


 Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
-------------- |----------:|----------:|----------:|-------:|----------:|
 IncrementBy1 |  48.73 ns | 0.2563 ns | 0.2397 ns | 0.0254 |      80 B |
 IncrementBy12 | 332.39 ns | 0.4090 ns | 0.3626 ns | 0.0429 |     136 B |
 Decrement | 340.12 ns | 2.8503 ns | 2.6662 ns | 0.0429 |     136 B |
 Timing | 381.85 ns | 0.4408 ns | 0.4123 ns | 0.0582 |     184 B |

		

After

 Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
-------------- |----------:|----------:|----------:|-------:|----------:|
 IncrementBy1 |  38.26 ns | 0.2169 ns | 0.2028 ns | 0.0254 |      80 B |
 IncrementBy12 | 178.74 ns | 0.9275 ns | 0.8676 ns | 0.0558 |     176 B |
 Decrement | 184.06 ns | 2.7020 ns | 2.5275 ns | 0.0558 |     176 B |
 Timing | 186.05 ns | 0.3100 ns | 0.2420 ns | 0.0608 |     192 B |

_Please include a reference to a GitHub issue if appropriate._
