### PR TITLE
Added overloads for Timing as a long number

### DIFF
--- a/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -107,6 +107,20 @@ namespace JustEat.StatsD.Extensions
             BucketNames.Add(bucket);
         }
 
+        public void Timing(long duration, string bucket)
+        {
+            CallCount++;
+            LastDuration = TimeSpan.FromMilliseconds(duration);
+            BucketNames.Add(bucket);
+        }
+
+        public void Timing(long duration, double sampleRate, string bucket)
+        {
+            CallCount++;
+            LastDuration = TimeSpan.FromMilliseconds(duration);
+            BucketNames.Add(bucket);
+        }
+
         public void MarkEvent(string name)
         {
             CallCount++;

--- a/src/JustEat.StatsD/IStatsDPublisher.cs
+++ b/src/JustEat.StatsD/IStatsDPublisher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace JustEat.StatsD
 {
@@ -18,6 +19,8 @@ namespace JustEat.StatsD
         void Gauge(long value, string bucket, DateTime timestamp);
         void Timing(TimeSpan duration, string bucket);
         void Timing(TimeSpan duration, double sampleRate, string bucket);
+        void Timing(long duration, string bucket);
+        void Timing(long duration, double sampleRate, string bucket);
         void MarkEvent(string name);
     }
 }

--- a/src/JustEat.StatsD/IStatsDPublisher.cs
+++ b/src/JustEat.StatsD/IStatsDPublisher.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 
 namespace JustEat.StatsD
 {

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -112,6 +112,16 @@ namespace JustEat.StatsD
             Send(_formatter.Timing(Convert.ToInt64(duration.TotalMilliseconds), sampleRate, bucket));
         }
 
+        public void Timing(long duration, string bucket)
+        {
+            Send(_formatter.Timing(duration, bucket));
+        }
+
+        public void Timing(long duration, double sampleRate, string bucket)
+        {
+            Send(_formatter.Timing(duration, sampleRate, bucket));
+        }
+
         public void MarkEvent(string name)
         {
             Send(_formatter.Event(name));


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Added overloads for `Timing` as a `long` number. Currently we only support `TimeSpan` which is converted internally to a `long` number of milliseconds. 

Why would you want to do this? 

 `TimeSpan` is the right type when the `Timing` is actually a duration. But it isn't always.

> It's been said before: one of the hardest things in programming is naming, and unfortunately, the Timing metric falls victim to this.  As you can see, it doesn't really have anything to do with "timing" - but it does give us a powerful way to summarize our data.
http://blog.scoutapp.com/articles/2015/08/04/de-mystifying-statsd-timer-metrics

> Timers collects numbers. They does not necessarily need to contain a value of time. You can collect bytes read, number of objects in some storage, or anything that is a number. A good thing about timer, is that you get the mean, the sum, the count, the upper and the lower values for free." 
https://blog.pkhamre.com/understanding-statsd-and-graphite/

If you want to use statsD to signal that something happened, you use `_publisher.Increment("some.thing.happened");` and you can answer questions like "count how often this thing happens per minute." etc.

If you want to use statsD to track a continuously varying quantity, where each new measurement is a variation on the last,  e.g. free bytes of memory, free disk space, CPU usage, in a "fuel gauge" manner then you use `_publisher.Gauge(value, "some.measure");` 

If you want to track values that vary, but not in a continuous way, then you use `Timing`. These values _can_ be durations, but not necessarily. Then you can answer the same questions as with an increment, but also statistical questions about the values, e.g. "when this thing happens, what is the average value recorded? What is the min, max, P95?" etc.

Grafana supports this usage, go to the "axes" tab of the graph and see the "unit" dropdown.

When they _are_ durations, it's still actually just a number, of milliseconds. With the new overload for timing numbers, all we do is skip that conversion from `TimeSpan` to `long`.

