### PR TITLE
Do not create 800b socket if we have nothing to send

### DIFF
--- a/src/JustEat.StatsD/IpTransport.cs
+++ b/src/JustEat.StatsD/IpTransport.cs
@@ -16,6 +16,9 @@ namespace JustEat.StatsD
 
         public void Send(string metric)
         {
+            if (string.IsNullOrWhiteSpace(metric))
+                return;
+
             var endpoint = _endpointSource.GetEndpoint();
             var bytes = Encoding.UTF8.GetBytes(metric);
 

--- a/src/JustEat.StatsD/IpTransport.cs
+++ b/src/JustEat.StatsD/IpTransport.cs
@@ -17,7 +17,9 @@ namespace JustEat.StatsD
         public void Send(string metric)
         {
             if (string.IsNullOrWhiteSpace(metric))
+            {
                 return;
+            }
 
             var endpoint = _endpointSource.GetEndpoint();
             var bytes = Encoding.UTF8.GetBytes(metric);

--- a/src/JustEat.StatsD/UdpTransport.cs
+++ b/src/JustEat.StatsD/UdpTransport.cs
@@ -20,7 +20,9 @@ namespace JustEat.StatsD
         public void Send(string metric)
         {
             if (string.IsNullOrWhiteSpace(metric))
+            {
                 return;
+            }
 
             var bytes = Encoding.UTF8.GetBytes(metric);
             var endpoint = _endpointSource.GetEndpoint();

--- a/src/JustEat.StatsD/UdpTransport.cs
+++ b/src/JustEat.StatsD/UdpTransport.cs
@@ -19,6 +19,9 @@ namespace JustEat.StatsD
 
         public void Send(string metric)
         {
+            if (string.IsNullOrWhiteSpace(metric))
+                return;
+
             var bytes = Encoding.UTF8.GetBytes(metric);
             var endpoint = _endpointSource.GetEndpoint();
 


### PR DESCRIPTION
There is a case on StatsDMessageFormatter when Random.NextDouble() is less than a sample rate. The formatted result is an empty string in this case. There is no value in creating a socket for sending empty payload.

