### PR TITLE
Benchmark some sampling cases

### DIFF
--- a/src/Benchmark/FormatterBenchmark.cs
+++ b/src/Benchmark/FormatterBenchmark.cs
@@ -21,6 +21,12 @@ namespace Benchmark
         }
 
         [Benchmark]
+        public string IncrementBy2WithSampling()
+        {
+            return _formatter.Increment(2, 0.5, "some.stat");
+        }
+
+        [Benchmark]
         public string Decrement()
         {
             return _formatter.Decrement(12, "some.stat");

--- a/src/Benchmark/StatSendingBenchmark.cs
+++ b/src/Benchmark/StatSendingBenchmark.cs
@@ -45,10 +45,22 @@ namespace Benchmark
         }
 
         [Benchmark]
+        public void RunUdpWithSampling()
+        {
+            _udpSender.Increment(2, 0.5, "increment.ud");
+        }
+
+        [Benchmark]
         public void RunIp()
         {
             _ipSender.Increment("increment.ip");
             _ipSender.Timing(Timed, "timer.ip");
+        }
+
+        [Benchmark]
+        public void RunIpWithSampling()
+        {
+            _ipSender.Increment(2, 0.5, "increment.ip");
         }
     }
 }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Add more benchmarks, on cases where there is a sampling rate. It tells us about the impact of #76 

Using a new StatSending benchmark: 

## Before #76 


|             Method |     Mean |    Error |   StdDev | Allocated |
|------------------- |---------:|---------:|---------:|----------:|
|             RunUdp | 341.9 us | 6.836 us | 6.714 us |    1184 B |
| RunUdpWithSampling | 172.7 us | 2.734 us | 2.557 us |     731 B |
|              RunIp | 313.7 us | 3.270 us | 2.899 us |    1184 B |
|  RunIpWithSampling | 166.7 us | 3.278 us | 3.644 us |     731 B |


## After #76

|             Method |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------------------- |----------:|---------:|---------:|-------:|----------:|
|             RunUdp | 394.85 us | 4.553 us | 3.555 us |      - |    1184 B |
| RunUdpWithSampling | 102.71 us | 1.397 us | 1.307 us | 0.1221 |     504 B |
|              RunIp | 372.77 us | 4.851 us | 3.788 us |      - |    1184 B |
|  RunIpWithSampling |  96.21 us | 1.765 us | 1.651 us | 0.1221 |     506 B |
  