### PR TITLE
Pool is flexibly sized

### DIFF
--- a/src/JustEat.StatsD.Tests/WhenUsingPooledUdpTransport.cs
+++ b/src/JustEat.StatsD.Tests/WhenUsingPooledUdpTransport.cs
@@ -42,7 +42,7 @@ namespace JustEat.StatsD
 
             using (var target = new PooledUdpTransport(endPointSource))
             {
-                Parallel.For(0, 10_000, (_) =>
+                Parallel.For(0, 10_000, _ =>
                 {
                     target.Send("mycustommetric");
                 });

--- a/src/JustEat.StatsD/PooledUdpTransport.cs
+++ b/src/JustEat.StatsD/PooledUdpTransport.cs
@@ -42,7 +42,16 @@ namespace JustEat.StatsD
             var endpoint = _endpointSource.GetEndpoint();
 
             var socket = _socketPool.Pop();
-            socket.SendTo(bytes, endpoint);
+            try
+            {
+                socket.SendTo(bytes, endpoint);
+            }
+            catch (Exception)
+            {
+                socket.Dispose();
+                throw;
+            }
+
             _socketPool.Push(socket);
         }
 

--- a/src/JustEat.StatsD/PooledUdpTransport.cs
+++ b/src/JustEat.StatsD/PooledUdpTransport.cs
@@ -41,7 +41,7 @@ namespace JustEat.StatsD
             var bytes = Encoding.UTF8.GetBytes(metric);
             var endpoint = _endpointSource.GetEndpoint();
 
-            var socket = _socketPool.Pop();
+            var socket = _socketPool.PopOrCreate();
             try
             {
                 socket.SendTo(bytes, endpoint);

--- a/src/JustEat.StatsD/PooledUdpTransport.cs
+++ b/src/JustEat.StatsD/PooledUdpTransport.cs
@@ -86,10 +86,7 @@ namespace JustEat.StatsD
                     while (_socketPool.Count > 0)
                     {
                         var socket = _socketPool.Pop();
-                        if (socket != null)
-                        {
-                            socket.Dispose();
-                        }
+                        socket?.Dispose();
                     }
                 }
                 catch (ObjectDisposedException)

--- a/src/JustEat.StatsD/SimpleObjectPool.cs
+++ b/src/JustEat.StatsD/SimpleObjectPool.cs
@@ -22,14 +22,14 @@ namespace JustEat.StatsD
             PrePopulate(initialSize);
         }
 
-        private void PrePopulate(int initialSize)
+        private void PrePopulate(int size)
         {
-            for (var i = 0; i < initialSize; ++i)
+            while (Count < size)
             {
                 var instance = _constructor(this);
                 if (instance == null)
                 {
-                    throw new ArgumentException("constructor produced null object");
+                    throw new InvalidOperationException("constructor produced null object");
                 }
 
                 _pool.Add(instance);

--- a/src/JustEat.StatsD/SimpleObjectPool.cs
+++ b/src/JustEat.StatsD/SimpleObjectPool.cs
@@ -36,10 +36,10 @@ namespace JustEat.StatsD
             }
         }
 
-        public int Count => _pool.Count;
+        internal int Count => _pool.Count;
 
         /// <summary>Retrieves an object from the pool if one is available.
-        /// Expand the pool if need be </summary>
+        /// return null if the pool is empty</summary>
         /// <returns>An object from the pool. </returns>
         public T Pop()
         {
@@ -48,7 +48,15 @@ namespace JustEat.StatsD
                 return result;
             }
 
-            return _constructor(this);
+            return null;
+        }
+
+        /// <summary>Retrieves an object from the pool if one is available.
+        /// Creates a new object if the pool is empty </summary>
+        /// <returns>An object from the pool. </returns>
+        internal T PopOrCreate()
+        {
+            return Pop() ?? _constructor(this);
         }
 
         /// <summary>	Pushes an object back into the pool. </summary>

--- a/src/JustEat.StatsD/SimpleObjectPool.cs
+++ b/src/JustEat.StatsD/SimpleObjectPool.cs
@@ -1,56 +1,59 @@
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics.CodeAnalysis;
 
 namespace JustEat.StatsD
 {
-    /// <summary>	A class that provides simple thread-safe object pooling semantics.  </summary>
-    public sealed class SimpleObjectPool<T>
-        where T : class
+    /// <summary>
+    /// A class that provides simple thread-safe object pooling semantics.
+    /// </summary>
+    public sealed class SimpleObjectPool<T> where T : class
     {
+        private readonly Func<SimpleObjectPool<T>, T> _constructor;
         private readonly ConcurrentBag<T> _pool;
 
         /// <summary>	Constructor that populates a pool with the given number of items. </summary>
-        /// <exception cref="ArgumentNullException">	Thrown when the constructor is null. </exception>
-        /// <exception cref="ArgumentException">		Thrown when the constructor produces null objects. </exception>
-        /// <param name="capacity">   	The capacity. </param>
-        /// <param name="constructor">	The factory method used to create new instances of the object to populate the pool. </param>
-        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Necessary to nest generics to support passing a factory method")]
-        public SimpleObjectPool(int capacity, Func<SimpleObjectPool<T>, T> constructor)
+        /// <exception cref="ArgumentNullException"> Thrown when the constructor is null. </exception>
+        /// <param name="initialSize"> Number of items in the pool at start </param>
+        /// <param name="constructor"> The factory method used to create new instances of the object to populate the pool. </param>
+        public SimpleObjectPool(int initialSize, Func<SimpleObjectPool<T>, T> constructor)
         {
-            if (constructor == null)
-            {
-                throw new ArgumentNullException(nameof(constructor));
-            }
-
+            _constructor = constructor ?? throw new ArgumentNullException(nameof(constructor));
             _pool = new ConcurrentBag<T>();
-            for (var i = 0; i < capacity; ++i)
+            PrePopulate(initialSize);
+        }
+
+        private void PrePopulate(int initialSize)
+        {
+            for (var i = 0; i < initialSize; ++i)
             {
-                var instance = constructor(this);
+                var instance = _constructor(this);
                 if (instance == null)
                 {
-                    throw new ArgumentException("constructor produced null object", "constructor");
+                    throw new ArgumentException("constructor produced null object");
                 }
 
                 _pool.Add(instance);
             }
         }
 
-        /// <summary>	Retrieves an object from the pool if one is available. </summary>
-        /// <returns>	An object or null if the pool has been exhausted. </returns>
+        public int Count => _pool.Count;
+
+        /// <summary>Retrieves an object from the pool if one is available.
+        /// Expand the pool if need be </summary>
+        /// <returns>An object from the pool. </returns>
         public T Pop()
         {
-            if (!_pool.TryTake(out T result))
+            if (_pool.TryTake(out T result))
             {
-                result = null;
+                return result;
             }
 
-            return result;
+            return _constructor(this);
         }
 
         /// <summary>	Pushes an object back into the pool. </summary>
-        /// <exception cref="ArgumentNullException">	Thrown when the item is null. </exception>
-        /// <param name="item">	The T to push. </param>
+        /// <exception cref="ArgumentNullException"> Thrown when the item is null.</exception>
+        /// <param name="item">The T to push.</param>
         public void Push(T item)
         {
             if (item == null)


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

`SimpleObjectPool` does not have a fixed size any more. It grows as needed using the constructor function. As used for Sockets in `PooledUdpTransport`, it starts small (1 socket per logical CPU core, i.e. 8 on my machine)

This means that you cannot use `Pop` in the `Dispose` as it will just create new items. So a `Count` property is needed to tell this when to stop.

There should not be a `try...finally` arounds socket use, as a socket that throws exception should not be put back in the pool.

FYI, the `Parallel.For` test uses a pool size of 8 (on my machine, assume that it's using 1 thread per core).

If I was breaking backwards compatibility I would also do:

- change `Func<SimpleObjectPool<T>, T>` to just `Func<T>` - the first param is not used at all.
* change the constructor of `SimpleObjectPool` to have the size as an optional param at the end. It is acceptable to start with a size of zero. i.e. `public SimpleObjectPool(Func<T> constructor, int initialSize = 0)`
* Why is it a _generic_ `SimpleObjectPool<T>` in the StatsD library, when we only ever put `Socket` objects in it? 

