### PR TITLE
Connected UDP Sockets Pool

### DIFF
--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -1,4 +1,8 @@
+using System.Linq;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
+using JustEat.StatsD;
+using JustEat.StatsD.EndpointLookups;
 
 namespace Benchmark
 {
@@ -6,10 +10,33 @@ namespace Benchmark
     {
         internal static void Main(string[] args)
         {
-            BenchmarkRunner.Run<StatSendingBenchmark>();
-            BenchmarkRunner.Run<FormatterBenchmark>();
+            var config = new StatsDConfiguration
+            {
+                Host = "127.0.0.1",
+            };
+
+            var endpointSource1 = EndpointParser.MakeEndPointSource(
+                config.Host,
+                config.Port,
+                config.DnsLookupInterval);
+
+            var endpointSource2 = EndpointParser.MakeEndPointSource(
+                config.Host,
+                config.Port + 2,
+                config.DnsLookupInterval);
+
+            var wtf = new MilisecondSwitcher(endpointSource1, endpointSource2);
+
+            var pooledTransport = new PooledUdpTransport(wtf);
+
+            Parallel.For(0, 10000, _ => pooledTransport.Send("hello.world.yo"));
+
+            pooledTransport.Dispose();
+
+            //BenchmarkRunner.Run<StatSendingBenchmark>();
+            //BenchmarkRunner.Run<FormatterBenchmark>();
             BenchmarkRunner.Run<UdpTransportBenchmark>();
-            BenchmarkRunner.Run<UdpStatSendingBenchmark>();
+            //BenchmarkRunner.Run<UdpStatSendingBenchmark>();
         }
     }
 }

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -1,8 +1,4 @@
-using System.Linq;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Running;
-using JustEat.StatsD;
-using JustEat.StatsD.EndpointLookups;
 
 namespace Benchmark
 {
@@ -10,29 +6,6 @@ namespace Benchmark
     {
         internal static void Main(string[] args)
         {
-            var config = new StatsDConfiguration
-            {
-                Host = "127.0.0.1",
-            };
-
-            var endpointSource1 = EndpointParser.MakeEndPointSource(
-                config.Host,
-                config.Port,
-                config.DnsLookupInterval);
-
-            var endpointSource2 = EndpointParser.MakeEndPointSource(
-                config.Host,
-                config.Port + 2,
-                config.DnsLookupInterval);
-
-            var wtf = new MilisecondSwitcher(endpointSource1, endpointSource2);
-
-            var pooledTransport = new PooledUdpTransport(wtf);
-
-            Parallel.For(0, 10000, _ => pooledTransport.Send("hello.world.yo"));
-
-            pooledTransport.Dispose();
-
             //BenchmarkRunner.Run<StatSendingBenchmark>();
             //BenchmarkRunner.Run<FormatterBenchmark>();
             BenchmarkRunner.Run<UdpTransportBenchmark>();

--- a/src/Benchmark/UdpTransportBenchmark.cs
+++ b/src/Benchmark/UdpTransportBenchmark.cs
@@ -51,7 +51,7 @@ namespace Benchmark
 
             var endpointSource2 = EndpointParser.MakeEndPointSource(
                 config.Host,
-                config.Port + 2,
+                config.Port + 1,
                 config.DnsLookupInterval);
 
             var switcher = new MilisecondSwitcher(endpointSource1, endpointSource2);

--- a/src/Benchmark/UdpTransportBenchmark.cs
+++ b/src/Benchmark/UdpTransportBenchmark.cs
@@ -1,15 +1,39 @@
+using System;
+using System.Net;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes.Jobs;
 using JustEat.StatsD;
 using JustEat.StatsD.EndpointLookups;
 
 namespace Benchmark
 {
+    public class MilisecondSwitcher : IPEndPointSource
+    {
+        private readonly IPEndPointSource _endpointSource1;
+        private readonly IPEndPointSource _endpointSource2;
+
+        public MilisecondSwitcher(IPEndPointSource endpointSource1, IPEndPointSource endpointSource2)
+        {
+            _endpointSource1 = endpointSource1;
+            _endpointSource2 = endpointSource2;
+        }
+
+        public IPEndPoint GetEndpoint()
+        {
+            return DateTime.Now.Millisecond % 2 == 0 ?
+                _endpointSource1.GetEndpoint() :
+                _endpointSource2.GetEndpoint();
+        }
+    }
+
     [MemoryDiagnoser]
+    [ShortRunJob]
     public class UdpTransportBenchmark
     {
         private const string MetricName = "this.is.a.metric";
 
         private PooledUdpTransport _pooledTransport;
+        private PooledUdpTransport _pooledTransportSwitched;
         private UdpTransport _unpooledTransport;
 
         [GlobalSetup]
@@ -20,23 +44,32 @@ namespace Benchmark
                 Host = "127.0.0.1",
             };
 
-            var endpointSource = EndpointParser.MakeEndPointSource(
+            var endpointSource1 = EndpointParser.MakeEndPointSource(
                 config.Host,
                 config.Port,
                 config.DnsLookupInterval);
 
-            _pooledTransport = new PooledUdpTransport(endpointSource);
-            _unpooledTransport = new UdpTransport(endpointSource);
+            var endpointSource2 = EndpointParser.MakeEndPointSource(
+                config.Host,
+                config.Port + 2,
+                config.DnsLookupInterval);
+
+            var switcher = new MilisecondSwitcher(endpointSource1, endpointSource2);
+
+            _pooledTransport = new PooledUdpTransport(endpointSource1);
+            _pooledTransportSwitched = new PooledUdpTransport(switcher);
+            _unpooledTransport = new UdpTransport(endpointSource1);
         }
 
         [GlobalCleanup]
         public void Cleanup()
         {
-            _pooledTransport.Dispose();
+            _pooledTransport?.Dispose();
+            _pooledTransportSwitched?.Dispose();
         }
 
         [Benchmark(Baseline = true)]
-        public void SendWithoutPool()
+        public void Send()
         {
             _unpooledTransport.Send(MetricName);
         }
@@ -45,6 +78,12 @@ namespace Benchmark
         public void SendWithPool()
         {
             _pooledTransport.Send(MetricName);
+        }
+
+        [Benchmark]
+        public void SendWithPoolSwitcher()
+        {
+            _pooledTransportSwitched.Send(MetricName);
         }
     }
 }

--- a/src/Benchmark/UdpTransportBenchmark.cs
+++ b/src/Benchmark/UdpTransportBenchmark.cs
@@ -78,10 +78,10 @@ namespace Benchmark
             _pooledTransport.Send(MetricName);
         }
 
-        //[Benchmark]
-        //public void SendWithPoolSwitcher()
-        //{
-        //    _pooledTransportSwitched.Send(MetricName);
-        //}
+        [Benchmark]
+        public void SendWithPoolSwitcher()
+        {
+            _pooledTransportSwitched.Send(MetricName);
+        }
     }
 }

--- a/src/Benchmark/UdpTransportBenchmark.cs
+++ b/src/Benchmark/UdpTransportBenchmark.cs
@@ -27,7 +27,6 @@ namespace Benchmark
     }
 
     [MemoryDiagnoser]
-    [ShortRunJob]
     public class UdpTransportBenchmark
     {
         private const string MetricName = "this.is.a.metric";
@@ -80,10 +79,10 @@ namespace Benchmark
             _pooledTransport.Send(MetricName);
         }
 
-        [Benchmark]
-        public void SendWithPoolSwitcher()
-        {
-            _pooledTransportSwitched.Send(MetricName);
-        }
+        //[Benchmark]
+        //public void SendWithPoolSwitcher()
+        //{
+        //    _pooledTransportSwitched.Send(MetricName);
+        //}
     }
 }

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
-    <PackageReference Include="Networker" Version="2.1.1" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Networker" Version="2.1.1" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/JustEat.StatsD.Tests/WhenUsingPooledUdpTransport.cs
+++ b/src/JustEat.StatsD.Tests/WhenUsingPooledUdpTransport.cs
@@ -1,58 +1,86 @@
 using System;
 using System.Net;
-using System.Threading;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using JustEat.StatsD.EndpointLookups;
 using Xunit;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
 namespace JustEat.StatsD
 {
-    public static class WhenUsingPooledUdpTransport
+    public sealed class UdpListener : IDisposable
     {
-        [Fact]
-        public static void AMetricCanBeSentWithoutAnExceptionBeingThrown()
-        {
-            // Arrange
-            var endPointSource = EndpointLookups.EndpointParser.MakeEndPointSource("127.0.0.1", 8125, null);
+        private readonly Socket _socket;
+        private EndPoint _endPoint;
 
-            using (var target = new PooledUdpTransport(endPointSource))
-            {
-                // Act and Assert
-                target.Send("mycustommetric");
-            }
+        public class State
+        {
+            public const int BufSize = 8 * 1024;
+            public readonly byte[] Buffer = new byte[BufSize];
         }
 
-        [Fact]
-        public static void MultipleMetricsCanBeSentWithoutAnExceptionBeingThrownSerial()
+        public UdpListener(int port)
         {
-            // Arrange
-            var endPointSource = EndpointLookups.EndpointParser.MakeEndPointSource("127.0.0.1", 8125, null);
-
-            using (var target = new PooledUdpTransport(endPointSource))
-            {
-                for (int i = 0; i < 10_000; i++)
-                {
-                    // Act and Assert
-                    target.Send("mycustommetric");
-                }
-            }
+            _socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            _endPoint = new IPEndPoint(IPAddress.Loopback, port);
+            _socket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.ReuseAddress, true);
         }
 
-        [Fact]
-        public static void MultipleMetricsCanBeSentWithoutAnExceptionBeingThrownParallel()
+        public void Start()
         {
-            // Arrange
-            var endPointSource = EndpointLookups.EndpointParser.MakeEndPointSource("127.0.0.1", 8125, null);
-
-            using (var target = new PooledUdpTransport(endPointSource))
+            var state = new State();
+            AsyncCallback recv = null;
+            
+            _socket.Bind(_endPoint);
+            _socket.BeginReceiveFrom(state.Buffer, 0, State.BufSize, SocketFlags.None, ref _endPoint, recv = (ar) =>
             {
-                Parallel.For(0, 10_000, _ =>
-                {
-                    target.Send("mycustommetric");
-                });
-            }
+                var so = (State)ar.AsyncState;
+                int _ = _socket.EndReceiveFrom(ar, ref _endPoint);
+                _socket.BeginReceiveFrom(so.Buffer, 0, State.BufSize, SocketFlags.None, ref _endPoint, recv, so);
+            }, state);
         }
 
+        public void Dispose()
+        {
+            _socket.Dispose();
+        }
+    }
+
+    public sealed class Servers : IDisposable
+    {
+        private readonly UdpListener _one;
+        private readonly UdpListener _two;
+
+        public Servers()
+        {
+            _one = new UdpListener(8125);
+            _two = new UdpListener(8126);
+
+            Start();
+        }
+
+        public void Start()
+        {
+            _one.Start();
+            _two.Start();
+        }
+
+        public void Dispose()
+        {
+            _one.Dispose();
+            _two.Dispose();
+        }
+    }
+
+    [CollectionDefinition("REAL_UDP", DisableParallelization = true)]
+    public class DatabaseCollection : ICollectionFixture<Servers>
+    {
+    }
+
+    [Collection("REAL_UDP")]
+    public class WhenUsingPooledUdpTransport 
+    {
         private class MilisecondSwitcher : IPEndPointSource
         {
             private readonly IPEndPointSource _endpointSource1;
@@ -72,8 +100,56 @@ namespace JustEat.StatsD
             }
         }
 
+        public WhenUsingPooledUdpTransport(Servers servers)
+        {
+        }
+
         [Fact]
-        public static void MultipleMetricsCanBeSentWithoutAnExceptionBeingThrownParallel_WithChangingEndpoints()
+        public void AMetricCanBeSentWithoutAnExceptionBeingThrown()
+        {
+            // Arrange
+            var endPointSource = EndpointLookups.EndpointParser.MakeEndPointSource("127.0.0.1", 8125, null);
+
+            using (var target = new PooledUdpTransport(endPointSource))
+            {
+                // Act and Assert
+                target.Send("mycustommetric");
+            }
+        }
+
+        [Fact]
+        public void MultipleMetricsCanBeSentWithoutAnExceptionBeingThrownSerial()
+        {
+            // Arrange
+            var endPointSource = EndpointLookups.EndpointParser.MakeEndPointSource("127.0.0.1", 8125, null);
+
+            using (var target = new PooledUdpTransport(endPointSource))
+            {
+                for (int i = 0; i < 10_000; i++)
+                {
+                    // Act and Assert
+                    target.Send("mycustommetric");
+                }
+            }
+        }
+
+        [Fact]
+        public void MultipleMetricsCanBeSentWithoutAnExceptionBeingThrownParallel()
+        {
+            // Arrange
+            var endPointSource = EndpointLookups.EndpointParser.MakeEndPointSource("127.0.0.1", 8125, null);
+
+            using (var target = new PooledUdpTransport(endPointSource))
+            {
+                Parallel.For(0, 10_000, _ =>
+                {
+                    target.Send("mycustommetric");
+                });
+            }
+        }
+
+        [Fact]
+        public void MultipleMetricsCanBeSentWithoutAnExceptionBeingThrownParallel_WithChangingEndpoints()
         {
             // Arrange
             var endPointSource1 = EndpointLookups.EndpointParser.MakeEndPointSource("127.0.0.1", 8125, null);
@@ -83,13 +159,12 @@ namespace JustEat.StatsD
 
             using (var target = new PooledUdpTransport(endPointSource))
             {
-                Parallel.For(0, 100_000, _ =>
+                Parallel.For(0, 10_000, _ =>
                 {
                     target.Send("mycustommetric");
                 });
             }
-
-            Thread.Sleep(5000);
         }
+
     }
 }

--- a/src/JustEat.StatsD/ConnectedSocketPool.cs
+++ b/src/JustEat.StatsD/ConnectedSocketPool.cs
@@ -26,7 +26,7 @@ namespace JustEat.StatsD
                     }
                     catch
                     {
-                        socket?.Dispose();
+                        socket.Dispose();
                         throw;
                     }
                 });

--- a/src/JustEat.StatsD/ConnectedSocketPool.cs
+++ b/src/JustEat.StatsD/ConnectedSocketPool.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+
+namespace JustEat.StatsD
+{
+    internal sealed class ConnectedSocketPool : IDisposable
+    {
+        private bool _disposed;
+        private readonly SimpleObjectPool<Socket> _pool;
+
+        public ConnectedSocketPool(IPEndPoint ipEndPoint)
+        {
+            IpEndPoint = ipEndPoint;
+
+            _pool = new SimpleObjectPool<Socket>(
+                Environment.ProcessorCount,
+                pool =>
+                {
+                    var socket = UdpTransport.CreateSocket();
+                    try
+                    {
+                        socket.Connect(ipEndPoint);
+                        return socket;
+                    }
+                    catch
+                    {
+                        socket?.Dispose();
+                        throw;
+                    }
+                });
+        }
+
+        public IPEndPoint IpEndPoint { get; }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Socket PopOrCreate()
+        {
+            return _pool.PopOrCreate();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Push(Socket item)
+        {
+            _pool.Push(item);
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="PooledUdpTransport"/> class.
+        /// </summary>
+        ~ConnectedSocketPool()
+        {
+            Dispose(false);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                try
+                {
+                    while (_pool.Count > 0)
+                    {
+                        var socket = _pool.Pop();
+                        socket?.Dispose();
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    // If the pool has already been disposed by the finalizer, ignore the exception
+                    if (disposing)
+                    {
+                        throw;
+                    }
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/JustEat.StatsD/ConnectedSocketPool.cs
+++ b/src/JustEat.StatsD/ConnectedSocketPool.cs
@@ -34,13 +34,11 @@ namespace JustEat.StatsD
 
         public IPEndPoint IpEndPoint { get; }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Socket PopOrCreate()
         {
             return _pool.PopOrCreate();
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Push(Socket item)
         {
             _pool.Push(item);


### PR DESCRIPTION
Thi pull request modifies PooledUdpTransport class by using a pool of connected udp sockets as discussed in #85 

Benchmarks results:

Before:

|          Method |     Mean |     Error |    StdDev |   Median | Scaled |  Gen 0 | Allocated |
|---------------- |---------:|----------:|----------:|---------:|-------:|-------:|----------:|
| SendWithoutPool | 53.76 us | 1.8980 us | 2.5338 us | 51.65 us |   1.00 | 0.1221 |     440 B |
|    SendWithPool | 14.08 us | 0.0811 us | 0.1189 us | 14.05 us |   0.26 | 0.0610 |     208 B |

After:

|Method |      Mean |     Error |    StdDev | Scaled |  Gen 0 | Allocated |
|--------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
|                 Send | 51.714 us | 0.1015 us | 0.0847 us |   1.00 | 0.1221 |     440 B |
|         SendWithPool |  8.890 us | 0.1292 us | 0.1209 us |   0.17 |      - |      40 B |
| SendWithPoolSwitcher | 11.839 us | 0.0425 us | 0.0398 us |   0.23 | 0.0153 |      67 B |


`SendWithPoolSwitcher` bench tests edge case when endpoint changes every milisecond