### PR TITLE
"Fix" flaky time test

### DIFF
--- a/src/JustEat.StatsD.Tests/Extensions/TimingConstants.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/TimingConstants.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace JustEat.StatsD.Extensions
 {
@@ -7,6 +7,6 @@ namespace JustEat.StatsD.Extensions
         public const int DelayMilliseconds = 500;
 
         public static readonly TimeSpan DeltaFast = TimeSpan.FromMilliseconds(DelayMilliseconds / 4);
-        public static readonly TimeSpan DeltaSlow = TimeSpan.FromMilliseconds(DelayMilliseconds * 2);
+        public static readonly TimeSpan DeltaSlow = TimeSpan.FromMilliseconds(DelayMilliseconds * 2.5);
     }
 }


### PR DESCRIPTION
"Fix" flaky timing test by allowing an extra `.5` of a magnitude of a fudge-factor.

Changed because 4 OS X builds in a row in master failed just now after I merged #87.
