### PR TITLE
Add convenience overload of EndpointParser.MakeEndPointSource()

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <LangVersion>latest</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/1516790?s=200</PackageIconUrl>
     <PackageProjectUrl>https://github.com/justeat/JustEat.StatsD</PackageProjectUrl>

--- a/src/JustEat.StatsD.Tests/WhenUsingPooledUdpTransport.cs
+++ b/src/JustEat.StatsD.Tests/WhenUsingPooledUdpTransport.cs
@@ -18,8 +18,7 @@ namespace JustEat.StatsD
         {
             // Arrange
             var endPointSource = EndpointParser.MakeEndPointSource(
-                UdpListeners.EndpointA.Address.ToString(),
-                UdpListeners.EndpointA.Port,
+                UdpListeners.EndpointA,
                 null);
 
             using (var target = new PooledUdpTransport(endPointSource))
@@ -34,8 +33,7 @@ namespace JustEat.StatsD
         {
             // Arrange
             var endPointSource = EndpointParser.MakeEndPointSource(
-                UdpListeners.EndpointA.Address.ToString(),
-                UdpListeners.EndpointA.Port,
+                UdpListeners.EndpointA,
                 null);
 
             using (var target = new PooledUdpTransport(endPointSource))
@@ -53,8 +51,7 @@ namespace JustEat.StatsD
         {
             // Arrange
             var endPointSource = EndpointParser.MakeEndPointSource(
-                UdpListeners.EndpointA.Address.ToString(),
-                UdpListeners.EndpointA.Port,
+                UdpListeners.EndpointA,
                 null);
 
             using (var target = new PooledUdpTransport(endPointSource))
@@ -72,13 +69,11 @@ namespace JustEat.StatsD
         {
             // Arrange
             var endPointSource1 = EndpointParser.MakeEndPointSource(
-                UdpListeners.EndpointA.Address.ToString(),
-                UdpListeners.EndpointA.Port,
+                UdpListeners.EndpointA,
                 null);
 
             var endPointSource2 = EndpointParser.MakeEndPointSource(
-                UdpListeners.EndpointB.Address.ToString(),
-                UdpListeners.EndpointB.Port,
+                UdpListeners.EndpointB,
                 null);
             
             using (var target = new PooledUdpTransport(new MilisecondSwitcher(endPointSource2, endPointSource1)))
@@ -96,13 +91,11 @@ namespace JustEat.StatsD
         {
             // Arrange
             var endPointSource1 = EndpointParser.MakeEndPointSource(
-                UdpListeners.EndpointA.Address.ToString(),
-                UdpListeners.EndpointA.Port,
+                UdpListeners.EndpointA,
                 null);
 
             var endPointSource2 = EndpointParser.MakeEndPointSource(
-                UdpListeners.EndpointB.Address.ToString(),
-                UdpListeners.EndpointB.Port,
+                UdpListeners.EndpointB,
                 null);
             
             using (var target = new PooledUdpTransport(new MilisecondSwitcher(endPointSource2, endPointSource1)))

--- a/src/JustEat.StatsD/EndpointLookups/EndpointParser.cs
+++ b/src/JustEat.StatsD/EndpointLookups/EndpointParser.cs
@@ -1,10 +1,20 @@
-﻿using System;
+using System;
 using System.Net;
 
 namespace JustEat.StatsD.EndpointLookups
 {
     public static class EndpointParser
     {
+        public static IPEndPointSource MakeEndPointSource(IPEndPoint endpoint, TimeSpan? endpointCacheDuration)
+        {
+            if (endpoint == null)
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+
+            return MakeEndPointSource(endpoint.Address.ToString(), endpoint.Port, endpointCacheDuration);
+        }
+
         public static IPEndPointSource MakeEndPointSource(string host, int port, TimeSpan? endpointCacheDuration)
         {
             if (string.IsNullOrWhiteSpace(host))

--- a/src/JustEat.StatsD/EndpointLookups/EndpointParser.cs
+++ b/src/JustEat.StatsD/EndpointLookups/EndpointParser.cs
@@ -12,7 +12,14 @@ namespace JustEat.StatsD.EndpointLookups
                 throw new ArgumentNullException(nameof(endpoint));
             }
 
-            return MakeEndPointSource(endpoint.Address.ToString(), endpoint.Port, endpointCacheDuration);
+            IPEndPointSource source = new SimpleIpEndpoint(endpoint);
+
+            if (!endpointCacheDuration.HasValue)
+            {
+                return source;
+            }
+
+            return new CachedIpEndpointSource(source, endpointCacheDuration.Value);
         }
 
         public static IPEndPointSource MakeEndPointSource(string host, int port, TimeSpan? endpointCacheDuration)
@@ -22,18 +29,17 @@ namespace JustEat.StatsD.EndpointLookups
                 throw new ArgumentException("statsd host is null or empty");
             }
 
-            IPAddress address;
-            if (IPAddress.TryParse(host, out address))
+            if (IPAddress.TryParse(host, out IPAddress address))
             {
-                //if we were given an IP instead of a hostname, 
+                // If we were given an IP instead of a hostname, 
                 // we can happily keep it the life of this class
                 var endpoint = new IPEndPoint(address, port);
                 return new SimpleIpEndpoint(endpoint);
             }
 
-            // we have a host name,
-            // so we use DNS lookup
+            // We have a host name, so we use DNS lookup
             var uncachedLookup = new DnsLookupIpEndpointSource(host, port);
+
             if (!endpointCacheDuration.HasValue)
             {
                 return uncachedLookup;


### PR DESCRIPTION
Add a convenience overload for `EndpointParser.MakeEndPointSource()` that accepts an `IPEndpoint` as discussed in #86.

