### PR TITLE
No auto push

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,6 @@ build_script:
 artifacts:
 - path: '**\$(APPVEYOR_PROJECT_NAME)*.nupkg'
   name: Nuget
-deploy:
-- provider: NuGet
-  api_key:
-    secure: 6MzbzEs4YdJKS67Gio5gEO8mNKmwfC4UHTCmECZ1KOutI6ndm4vAECazmVNB6an7
-  artifact: /.*nupkg/
 notifications:
 - provider: HipChat
   room: 'Eng :: Open Source'


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Appveyor config change 

do not automatically push to nuget even on a tag. This is unnecessary, even harmful.
you can do it in the appveyor ui in 2 clicks, and  it's occasional enough and important enough to first verify the package version.

Yes, it has gone wrong today

I am not 100% sure if this is the right syntax. Please comment if you know.