### PR TITLE
Fix version suffix for AppVeyor tag builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <LangVersion>latest</LangVersion>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageIconUrl>https://avatars3.githubusercontent.com/u/1516790?s=200</PackageIconUrl>
     <PackageProjectUrl>https://github.com/justeat/JustEat.StatsD</PackageProjectUrl>

--- a/version.props
+++ b/version.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <VersionPrefix>3.1.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
 
@@ -8,5 +9,6 @@
     <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
     <VersionSuffix Condition=" '$(APPVEYOR_REPO_TAG)' != 'true' AND '$(VersionSuffix)' != '' ">$(VersionSuffix)-build$(BuildNumber)</VersionSuffix>
     <VersionSuffix Condition=" '$(APPVEYOR_REPO_TAG)' != 'true' AND '$(VersionSuffix)' == '' ">build$(BuildNumber)</VersionSuffix>
+    <VersionSuffix Condition=" '$(APPVEYOR_REPO_TAG)' == 'true' AND '$(APPVEYOR_REPO_TAG_NAME)' != '' AND '$(APPVEYOR_REPO_TAG_NAME.Contains(`-`))' == 'true' ">$(APPVEYOR_REPO_TAG_NAME.Substring($(APPVEYOR_REPO_TAG_NAME.IndexOf(`-`))).Substring(1))</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fix the suffix from a GitHub tag that triggers an AppVeyor build not being used to version the NuGet package.

Also add the `MSBuildAllProjects` property to the `.props` files so they invalidate the MSBuild cache for builds.

## Test for a tag for a beta

Produces `JustEat.StatsD.3.1.0-beta-012.nupkg`.

--------------------------------------------------------------------------------

```ps
PS C:\Coding\JustEat.StatsD> $env:APPVEYOR_REPO_TAG_NAME = "v3.1.0-beta-012"
PS C:\Coding\JustEat.StatsD> $env:APPVEYOR_REPO_TAG = "true"
PS C:\Coding\JustEat.StatsD> .\Build.ps1
Building 1 projects...
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 40.51 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\artifacts\netstandard2.0\JustEat.StatsD.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.17
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 41 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\artifacts\net451\JustEat.StatsD.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:00.99
Testing 1 project(s)...
Build started, please wait...
Build completed.

Test run for C:\Coding\JustEat.StatsD\src\JustEat.StatsD.Tests\bin\Debug\netcoreapp2.1\JustEat.StatsD.Tests.dll(.NETCore
App,Version=v2.1)
Microsoft (R) Test Execution Command Line Tool Version 15.7.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 71. Passed: 71. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 14.4367 Seconds
Creating 1 package(s)...
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 47.55 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\src\JustEat.StatsD\bin\Release\netstandard2.0\JustEat.StatsD.dll
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\src\JustEat.StatsD\bin\Release\net451\JustEat.StatsD.dll
  Successfully created package 'C:\Coding\JustEat.StatsD\artifacts\JustEat.StatsD.3.1.0-beta-012.nupkg'.
  Successfully created package 'C:\Coding\JustEat.StatsD\artifacts\JustEat.StatsD.3.1.0-beta-012.symbols.nupkg'.
PS C:\Coding\JustEat.StatsD>
```

## Test for a full release

Produces `JustEat.StatsD.3.1.0.nupkg`.

--------------------------------------------------------------------------------

```ps
PS C:\Coding\JustEat.StatsD> $env:APPVEYOR_REPO_TAG_NAME = "v3.1.0"
PS C:\Coding\JustEat.StatsD> $env:APPVEYOR_REPO_TAG = "true"
PS C:\Coding\JustEat.StatsD> .\Build.ps1
Building 1 projects...
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restoring packages for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj...
  Restore completed in 173.23 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\artifacts\netstandard2.0\JustEat.StatsD.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.25
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 40.73 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\artifacts\net451\JustEat.StatsD.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.07
Testing 1 project(s)...
Build started, please wait...
Build completed.

Test run for C:\Coding\JustEat.StatsD\src\JustEat.StatsD.Tests\bin\Debug\netcoreapp2.1\JustEat.StatsD.Tests.dll(.NETCore
App,Version=v2.1)
Microsoft (R) Test Execution Command Line Tool Version 15.7.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 71. Passed: 71. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 14.2912 Seconds
Creating 1 package(s)...
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 49.16 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\src\JustEat.StatsD\bin\Release\netstandard2.0\JustEat.StatsD.dll
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\src\JustEat.StatsD\bin\Release\net451\JustEat.StatsD.dll
  Successfully created package 'C:\Coding\JustEat.StatsD\artifacts\JustEat.StatsD.3.1.0.nupkg'.
  Successfully created package 'C:\Coding\JustEat.StatsD\artifacts\JustEat.StatsD.3.1.0.symbols.nupkg'.
PS C:\Coding\JustEat.StatsD>
```

## Normal local build

Produces `JustEat.StatsD.3.1.0-build0.nupkg`.

--------------------------------------------------------------------------------

ps
```
PS C:\Coding\JustEat.StatsD> .\Build.ps1
Building 1 projects...
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restoring packages for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj...
  Restore completed in 210.27 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\artifacts\netstandard2.0\JustEat.StatsD.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.33
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 42.65 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\artifacts\net451\JustEat.StatsD.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.09
Testing 1 project(s)...
Build started, please wait...
Build completed.

Test run for C:\Coding\JustEat.StatsD\src\JustEat.StatsD.Tests\bin\Debug\netcoreapp2.1\JustEat.StatsD.Tests.dll(.NETCore
App,Version=v2.1)
Microsoft (R) Test Execution Command Line Tool Version 15.7.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...

Total tests: 71. Passed: 71. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 14.5965 Seconds
Creating 1 package(s)...
Microsoft (R) Build Engine version 15.7.179.6572 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 40.33 ms for C:\Coding\JustEat.StatsD\src\JustEat.StatsD\JustEat.StatsD.csproj.
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\src\JustEat.StatsD\bin\Release\netstandard2.0\JustEat.StatsD.dll
  JustEat.StatsD -> C:\Coding\JustEat.StatsD\src\JustEat.StatsD\bin\Release\net451\JustEat.StatsD.dll
  Successfully created package 'C:\Coding\JustEat.StatsD\artifacts\JustEat.StatsD.3.1.0-build0.nupkg'.
  Successfully created package 'C:\Coding\JustEat.StatsD\artifacts\JustEat.StatsD.3.1.0-build0.symbols.nupkg'.
PS C:\Coding\JustEat.StatsD>
```