### PR TITLE
Use shorter .NET Core SDK download links

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -42,7 +42,7 @@ if ($installDotNetSdk -eq $true) {
     if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
         mkdir $env:DOTNET_INSTALL_DIR | Out-Null
         $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
-        Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/v$dotnetVersion/scripts/obtain/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
+        Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
         & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
     }
 

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ export PATH="$DOTNET_INSTALL_DIR:$PATH"
 dotnet_version=$(dotnet --version)
 
 if [ "$dotnet_version" != "$CLI_VERSION" ]; then
-    curl -sSL https://raw.githubusercontent.com/dotnet/cli/v$CLI_VERSION/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 
 dotnet build src/JustEat.StatsD/JustEat.StatsD.csproj --output $artifacts --configuration $configuration --framework "netstandard2.0" || exit 1


### PR DESCRIPTION
Use convenience download URL for the .NET Core SDK installation script that I found [here](https://github.com/Microsoft/azure-pipelines-image-generation/blob/def0bc672d17fcefbe0ab9f5f75ab5b9e950d052/images/win/scripts/Installers/Install-DotnetSDK.ps1#L17).