### PR TITLE
Remove gauge timestamps

### DIFF
--- a/src/JustEat.StatsD.Tests/WhenRecordingGauges.cs
+++ b/src/JustEat.StatsD.Tests/WhenRecordingGauges.cs
@@ -33,38 +33,5 @@ namespace JustEat.StatsD
 
             actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|g", statBucket, magnitude));
         }
-
-        [Fact]
-        public static void GaugeMetricsAreFormattedCorrectlyWhenTheyContainATimestamp()
-        {
-            string statBucket = "gauge-bucket";
-            //generate a random double value between 0.1 and 100
-            double magnitude = new Random().NextDouble() * (100 - 0.1) + 0.1;
-
-            var target = new StatsDMessageFormatter();
-
-            var timestamp = DateTime.Now;
-
-            string actual = target.Gauge(magnitude, statBucket, timestamp);
-
-            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|g|@{2}", statBucket, magnitude, timestamp.AsUnixTime()));
-
-        }
-
-        [Fact]
-        public static void GaugeMetricsAreFormattedCorrectlyWhenTheyContainATimestampUsingDouble()
-        {
-            string statBucket = "gauge-bucket";
-            long magnitude = new Random().Next(100);
-
-            var target = new StatsDMessageFormatter();
-
-            var timestamp = DateTime.Now;
-
-            string actual = target.Gauge(magnitude, statBucket, timestamp);
-
-            actual.ShouldBe(string.Format(CultureInfo.InvariantCulture, "{0}:{1}|g|@{2}", statBucket, magnitude, timestamp.AsUnixTime()));
-
-        }
     }
 }

--- a/src/JustEat.StatsD/IStatsDPublisher.cs
+++ b/src/JustEat.StatsD/IStatsDPublisher.cs
@@ -13,9 +13,7 @@ namespace JustEat.StatsD
         void Decrement(long value, double sampleRate, string bucket);
         void Decrement(long value, double sampleRate, params string[] buckets);
         void Gauge(double value, string bucket);
-        void Gauge(double value, string bucket, DateTime timestamp);
         void Gauge(long value, string bucket);
-        void Gauge(long value, string bucket, DateTime timestamp);
         void Timing(TimeSpan duration, string bucket);
         void Timing(TimeSpan duration, double sampleRate, string bucket);
         void Timing(long duration, string bucket);

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -111,21 +111,10 @@ namespace JustEat.StatsD
             var stat = string.Format(InvariantCulture, "{0}{1}:{2}|g", _prefix, statBucket, magnitude);
             return Format(DefaultSampleRate, stat);
         }
-        public string Gauge(double magnitude, string statBucket, DateTime timestamp)
-        {
-            var stat = string.Format(InvariantCulture, "{0}{1}:{2}|g|@{3}", _prefix, statBucket, magnitude, timestamp.AsUnixTime());
-            return Format(DefaultSampleRate, stat);
-        }
 
         public string Gauge(long magnitude, string statBucket)
         {
             var stat = string.Format(InvariantCulture, "{0}{1}:{2}|g", _prefix, statBucket, magnitude);
-            return Format(DefaultSampleRate, stat);
-        }
-
-        public string Gauge(long magnitude, string statBucket, DateTime timestamp)
-        {
-            var stat = string.Format(InvariantCulture, "{0}{1}:{2}|g|@{3}", _prefix, statBucket, magnitude, timestamp.AsUnixTime());
             return Format(DefaultSampleRate, stat);
         }
 

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -108,19 +108,9 @@ namespace JustEat.StatsD
             _inner.Gauge(value, bucket);
         }
 
-        public void Gauge(double value, string bucket, DateTime timestamp)
-        {
-            _inner.Gauge(value, bucket, timestamp);
-        }
-
         public void Gauge(long value, string bucket)
         {
             _inner.Gauge(value, bucket);
-        }
-
-        public void Gauge(long value, string bucket, DateTime timestamp)
-        {
-            _inner.Gauge(value, bucket, timestamp);
         }
 
         public void Timing(TimeSpan duration, string bucket)

--- a/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
@@ -87,19 +87,9 @@ namespace JustEat.StatsD
             Send(_formatter.Gauge(value, bucket));
         }
 
-        public void Gauge(double value, string bucket, DateTime timestamp)
-        {
-            Send(_formatter.Gauge(value, bucket, timestamp));
-        }
-
         public void Gauge(long value, string bucket)
         {
             Send(_formatter.Gauge(value, bucket));
-        }
-
-        public void Gauge(long value, string bucket, DateTime timestamp)
-        {
-            Send(_formatter.Gauge(value, bucket, timestamp));
         }
 
         public void Timing(TimeSpan duration, string bucket)


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

remove overloads where a gauge (and only a gauge) can have a `DateTime` value for unknown historical reasons.

_Please include a reference to a GitHub issue if appropriate._

As discussed in  #103
