### PR TITLE
when formatting timing use miliseconds instead of ticks

### DIFF
--- a/src/JustEat.StatsD.Tests/BufferBasedStatsDPublisherTests.cs
+++ b/src/JustEat.StatsD.Tests/BufferBasedStatsDPublisherTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using JustEat.StatsD.Buffered;
+using Shouldly;
+using Xunit;
+
+namespace JustEat.StatsD
+{
+    public class BufferBasedStatsDPublisherTests
+    {
+        private readonly FakeTransport _transport = new FakeTransport();
+        private readonly StatsDConfiguration _configuration = new StatsDConfiguration { Prefix = "test" };
+        private readonly BufferBasedStatsDPublisher _sut;
+
+        public BufferBasedStatsDPublisherTests()
+        {
+            _sut = new BufferBasedStatsDPublisher(_configuration, _transport);
+        }
+
+        [Fact]
+        public void TestTiming_TimeSpan()
+        {
+            _sut.Timing(TimeSpan.FromSeconds(1.234), "timing");
+            _transport.Messages.ShouldHaveSingleItem("test.timing:1234|ms");
+        }
+
+        [Fact]
+        public void TestTimingSampled_TimeSpan()
+        {
+            for (int i = 0; _transport.Messages.Count == 0 && i < 10000; i++)
+            {
+                _sut.Timing(TimeSpan.FromSeconds(1.234), 0.99, "timing");
+            }
+            _transport.Messages.ShouldHaveSingleItem("test.timing:1234|ms|@0.99");
+        }
+
+        [Fact]
+        public void TestTiming_Long()
+        {
+            _sut.Timing(1234, "timing");
+            _transport.Messages.ShouldHaveSingleItem("test.timing:1234|ms");
+        }
+
+        [Fact]
+        public void TestTimingSampled_Long()
+        {
+            for (int i = 0; _transport.Messages.Count == 0 && i < 10000; i++)
+            {
+                _sut.Timing(1234, 0.99, "timing");
+            }
+            _transport.Messages.ShouldHaveSingleItem("test.timing:1234|ms|@0.99");
+        }
+
+        private class FakeTransport : IStatsDBufferedTransport
+        {
+            public List<string> Messages { get; } = new List<string>();
+
+            public void Send(in ArraySegment<byte> metric)
+            {
+                Messages.Add(Encoding.UTF8.GetString(metric.Array, metric.Offset, metric.Count));
+            }
+        }
+    }
+}

--- a/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
@@ -110,12 +110,12 @@ namespace JustEat.StatsD.Buffered
 
         public void Timing(TimeSpan duration, string bucket)
         {
-            Timing(duration.Ticks, bucket);
+            Timing((long)duration.TotalMilliseconds, bucket);
         }
 
         public void Timing(TimeSpan duration, double sampleRate, string bucket)
         {
-            Timing(duration.Ticks, sampleRate, bucket);
+            Timing((long)duration.TotalMilliseconds, sampleRate, bucket);
         }
 
         public void Timing(long duration, string bucket)


### PR DESCRIPTION
Timing was using ticks instead of milliseconds :sigh:

Fixes #110 
