### PR TITLE
Rename pooled

### DIFF
--- a/src/Benchmark/StatSendingBenchmark.cs
+++ b/src/Benchmark/StatSendingBenchmark.cs
@@ -32,7 +32,7 @@ namespace Benchmark
             _ipSender = new StringBasedStatsDPublisher(config, ipTransport);
             _ipSender.Increment("startup.ip");
 
-            var pooledUdpTransport = new PooledUdpTransport(endpointSource);
+            var pooledUdpTransport = new UdpTransport(endpointSource);
             _pooledUdpSender = new BufferBasedStatsDPublisher(config, pooledUdpTransport);
             _pooledUdpSender.Increment("startup.v2");
         }

--- a/src/Benchmark/StatSendingBenchmark.cs
+++ b/src/Benchmark/StatSendingBenchmark.cs
@@ -19,7 +19,7 @@ namespace Benchmark
         {
             var config = new StatsDConfiguration
             {
-                // if you want verify that stats are received,
+                // if you want to verify that stats are received,
                 // you will need the IP of suitable local test stats server
                 Host = "127.0.0.1",
                 Prefix = "testmetric"

--- a/src/Benchmark/StatSendingBenchmark.cs
+++ b/src/Benchmark/StatSendingBenchmark.cs
@@ -9,7 +9,7 @@ namespace Benchmark
     [MemoryDiagnoser]
     public class StatSendingBenchmark
     {
-        private BufferBasedStatsDPublisher _pooledUdpSender;
+        private BufferBasedStatsDPublisher _udpSender;
         private StringBasedStatsDPublisher _ipSender;
 
         private static readonly TimeSpan Timed = TimeSpan.FromMinutes(1);
@@ -32,9 +32,9 @@ namespace Benchmark
             _ipSender = new StringBasedStatsDPublisher(config, ipTransport);
             _ipSender.Increment("startup.ip");
 
-            var pooledUdpTransport = new UdpTransport(endpointSource);
-            _pooledUdpSender = new BufferBasedStatsDPublisher(config, pooledUdpTransport);
-            _pooledUdpSender.Increment("startup.v2");
+            var udpTransport = new UdpTransport(endpointSource);
+            _udpSender = new BufferBasedStatsDPublisher(config, udpTransport);
+            _udpSender.Increment("startup.v2");
         }
 
 
@@ -51,18 +51,18 @@ namespace Benchmark
         [Benchmark]
         public void RunBuffered()
         {
-            _pooledUdpSender.MarkEvent("hello.v2");
-            _pooledUdpSender.Increment(20, "increment.v2");
-            _pooledUdpSender.Timing(Timed, "timer.v2");
-            _pooledUdpSender.Gauge(354654, "gauge.v2");
-            _pooledUdpSender.Gauge(25.1, "free-space.v2");
+            _udpSender.MarkEvent("hello.v2");
+            _udpSender.Increment(20, "increment.v2");
+            _udpSender.Timing(Timed, "timer.v2");
+            _udpSender.Gauge(354654, "gauge.v2");
+            _udpSender.Gauge(25.1, "free-space.v2");
         }
 
         [Benchmark]
         public void RunBufferedWithSampling()
         {
-            _pooledUdpSender.Increment(2, 0.2, "increment.v2");
-            _pooledUdpSender.Timing(2, 0.2, "increment.v2");
+            _udpSender.Increment(2, 0.2, "increment.v2");
+            _udpSender.Timing(2, 0.2, "increment.v2");
         }
     }
 }

--- a/src/Benchmark/UdpStatSendingBenchmark.cs
+++ b/src/Benchmark/UdpStatSendingBenchmark.cs
@@ -11,7 +11,7 @@ namespace Benchmark
     {
         private static readonly TimeSpan Timed = TimeSpan.FromMinutes(1);
 
-        private PooledUdpTransport _pooledTransport;
+        private UdpTransport _transport;
         private StringBasedStatsDPublisher _pooledUdpSender;
         private BufferBasedStatsDPublisher _bufferBasedStatsDPublisher;
         private IStatsDPublisher _adaptedStatsDPublisher;
@@ -32,22 +32,22 @@ namespace Benchmark
                 config.Port,
                 config.DnsLookupInterval);
 
-            _pooledTransport = new PooledUdpTransport(endpointSource);
+            _transport = new UdpTransport(endpointSource);
 
-            _pooledUdpSender = new StringBasedStatsDPublisher(config, _pooledTransport);
+            _pooledUdpSender = new StringBasedStatsDPublisher(config, _transport);
             _pooledUdpSender.Increment("startup.ud");
 
             _adaptedStatsDPublisher = new StatsDPublisher(config);
             _adaptedStatsDPublisher.Increment("startup.ud");
 
-            _bufferBasedStatsDPublisher = new BufferBasedStatsDPublisher(config, _pooledTransport);
+            _bufferBasedStatsDPublisher = new BufferBasedStatsDPublisher(config, _transport);
             _bufferBasedStatsDPublisher.Increment("startup.ud");
         }
 
         [GlobalCleanup]
         public void Cleanup()
         {
-            _pooledTransport.Dispose();
+            _transport.Dispose();
         }
 
         [Benchmark]

--- a/src/Benchmark/UdpStatSendingBenchmark.cs
+++ b/src/Benchmark/UdpStatSendingBenchmark.cs
@@ -21,7 +21,7 @@ namespace Benchmark
         {
             var config = new StatsDConfiguration
             {
-                // if you want verify that stats are received,
+                // if you want to verify that stats are received,
                 // you will need the IP of suitable local test stats server
                 Host = "127.0.0.1",
                 Prefix = "testmetric"

--- a/src/Benchmark/UdpStatSendingBenchmark.cs
+++ b/src/Benchmark/UdpStatSendingBenchmark.cs
@@ -12,7 +12,7 @@ namespace Benchmark
         private static readonly TimeSpan Timed = TimeSpan.FromMinutes(1);
 
         private UdpTransport _transport;
-        private StringBasedStatsDPublisher _pooledUdpSender;
+        private StringBasedStatsDPublisher _udpSender;
         private BufferBasedStatsDPublisher _bufferBasedStatsDPublisher;
         private IStatsDPublisher _adaptedStatsDPublisher;
 
@@ -21,7 +21,7 @@ namespace Benchmark
         {
             var config = new StatsDConfiguration
             {
-                // if you want verify that stats are recevied,
+                // if you want verify that stats are received,
                 // you will need the IP of suitable local test stats server
                 Host = "127.0.0.1",
                 Prefix = "testmetric"
@@ -34,8 +34,8 @@ namespace Benchmark
 
             _transport = new UdpTransport(endpointSource);
 
-            _pooledUdpSender = new StringBasedStatsDPublisher(config, _transport);
-            _pooledUdpSender.Increment("startup.ud");
+            _udpSender = new StringBasedStatsDPublisher(config, _transport);
+            _udpSender.Increment("startup.ud");
 
             _adaptedStatsDPublisher = new StatsDPublisher(config);
             _adaptedStatsDPublisher.Increment("startup.ud");
@@ -51,21 +51,21 @@ namespace Benchmark
         }
 
         [Benchmark]
-        public void SendStatPooledUdp()
+        public void SendStatUdp()
         {
-            _pooledUdpSender.Increment("increment.ud");
-            _pooledUdpSender.Timing(Timed, "timer.ud");
+            _udpSender.Increment("increment.ud");
+            _udpSender.Timing(Timed, "timer.ud");
         }
 
         [Benchmark]
-        public void SendStatPooledUdpBuffered()
+        public void SendStatUdpBuffered()
         {
             _bufferBasedStatsDPublisher.Increment("increment.ud");
             _bufferBasedStatsDPublisher.Timing(Timed, "timer.ud");
         }
 
         [Benchmark]
-        public void SendStatPooledUdpCoveredByAdapter()
+        public void SendStatUdpCoveredByAdapter()
         {
             _adaptedStatsDPublisher.Increment("increment.ud");
             _adaptedStatsDPublisher.Timing(Timed, "timer.ud");

--- a/src/Benchmark/UdpTransportBenchmark.cs
+++ b/src/Benchmark/UdpTransportBenchmark.cs
@@ -65,13 +65,13 @@ namespace Benchmark
         }
 
         [Benchmark]
-        public void SendWithPool()
+        public void Send()
         {
             _transport.Send(MetricName);
         }
 
         [Benchmark]
-        public void SendWithPoolSwitcher()
+        public void SendWithSwitcher()
         {
             _transportSwitched.Send(MetricName);
         }

--- a/src/Benchmark/UdpTransportBenchmark.cs
+++ b/src/Benchmark/UdpTransportBenchmark.cs
@@ -11,8 +11,8 @@ namespace Benchmark
     {
         private const string MetricName = "this.is.a.metric";
 
-        private PooledUdpTransport _pooledTransport;
-        private PooledUdpTransport _pooledTransportSwitched;
+        private UdpTransport _transport;
+        private UdpTransport _transportSwitched;
 
         private class MilisecondSwitcher : IPEndPointSource
         {
@@ -53,27 +53,27 @@ namespace Benchmark
 
             var switcher = new MilisecondSwitcher(endpointSource1, endpointSource2);
 
-            _pooledTransport = new PooledUdpTransport(endpointSource1);
-            _pooledTransportSwitched = new PooledUdpTransport(switcher);
+            _transport = new UdpTransport(endpointSource1);
+            _transportSwitched = new UdpTransport(switcher);
         }
 
         [GlobalCleanup]
         public void Cleanup()
         {
-            _pooledTransport?.Dispose();
-            _pooledTransportSwitched?.Dispose();
+            _transport?.Dispose();
+            _transportSwitched?.Dispose();
         }
 
         [Benchmark]
         public void SendWithPool()
         {
-            _pooledTransport.Send(MetricName);
+            _transport.Send(MetricName);
         }
 
         [Benchmark]
         public void SendWithPoolSwitcher()
         {
-            _pooledTransportSwitched.Send(MetricName);
+            _transportSwitched.Send(MetricName);
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
+++ b/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
@@ -41,7 +41,7 @@ namespace JustEat.StatsD
 
                 var transport = provider.GetRequiredService<IStatsDTransport>();
                 transport.ShouldNotBeNull();
-                transport.ShouldBeOfType<PooledUdpTransport>();
+                transport.ShouldBeOfType<UdpTransport>();
 
                 var publisher = provider.GetRequiredService<IStatsDPublisher>();
                 publisher.ShouldNotBeNull();
@@ -82,7 +82,7 @@ namespace JustEat.StatsD
 
                 var transport = provider.GetRequiredService<IStatsDTransport>();
                 transport.ShouldNotBeNull();
-                transport.ShouldBeOfType<PooledUdpTransport>();
+                transport.ShouldBeOfType<UdpTransport>();
 
                 var publisher = provider.GetRequiredService<IStatsDPublisher>();
                 publisher.ShouldNotBeNull();
@@ -124,7 +124,7 @@ namespace JustEat.StatsD
 
                 var transport = provider.GetRequiredService<IStatsDTransport>();
                 transport.ShouldNotBeNull();
-                transport.ShouldBeOfType<PooledUdpTransport>();
+                transport.ShouldBeOfType<UdpTransport>();
 
                 var publisher = provider.GetRequiredService<IStatsDPublisher>();
                 publisher.ShouldNotBeNull();
@@ -179,7 +179,7 @@ namespace JustEat.StatsD
 
                 var transport = provider.GetRequiredService<IStatsDTransport>();
                 transport.ShouldNotBeNull();
-                transport.ShouldBeOfType<PooledUdpTransport>();
+                transport.ShouldBeOfType<UdpTransport>();
 
                 var publisher = provider.GetRequiredService<IStatsDPublisher>();
                 publisher.ShouldNotBeNull();

--- a/src/JustEat.StatsD.Tests/WhenUsingPooledUdpTransport.cs
+++ b/src/JustEat.StatsD.Tests/WhenUsingPooledUdpTransport.cs
@@ -21,7 +21,7 @@ namespace JustEat.StatsD
                 UdpListeners.EndpointA,
                 null);
 
-            using (var target = new PooledUdpTransport(endPointSource))
+            using (var target = new UdpTransport(endPointSource))
             {
                 // Act and Assert
                 target.Send("mycustommetric");
@@ -36,7 +36,7 @@ namespace JustEat.StatsD
                 UdpListeners.EndpointA,
                 null);
 
-            using (var target = new PooledUdpTransport(endPointSource))
+            using (var target = new UdpTransport(endPointSource))
             {
                 for (int i = 0; i < 10_000; i++)
                 {
@@ -54,7 +54,7 @@ namespace JustEat.StatsD
                 UdpListeners.EndpointA,
                 null);
 
-            using (var target = new PooledUdpTransport(endPointSource))
+            using (var target = new UdpTransport(endPointSource))
             {
                 Parallel.For(0, 10_000, _ =>
                 {
@@ -76,7 +76,7 @@ namespace JustEat.StatsD
                 UdpListeners.EndpointB,
                 null);
             
-            using (var target = new PooledUdpTransport(new MilisecondSwitcher(endPointSource2, endPointSource1)))
+            using (var target = new UdpTransport(new MilisecondSwitcher(endPointSource2, endPointSource1)))
             {
                 for (int i = 0; i < 10_000; i++)
                 {
@@ -98,7 +98,7 @@ namespace JustEat.StatsD
                 UdpListeners.EndpointB,
                 null);
             
-            using (var target = new PooledUdpTransport(new MilisecondSwitcher(endPointSource2, endPointSource1)))
+            using (var target = new UdpTransport(new MilisecondSwitcher(endPointSource2, endPointSource1)))
             {
                 Parallel.For(0, 10_000, _ =>
                 {

--- a/src/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
+++ b/src/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
@@ -7,9 +7,9 @@ using Xunit;
 namespace JustEat.StatsD
 {
     [Collection("ActiveUdpListeners")]
-    public class WhenUsingPooledUdpTransport 
+    public class WhenUsingUdpTransport 
     {
-        public WhenUsingPooledUdpTransport(UdpListeners _)
+        public WhenUsingUdpTransport(UdpListeners _)
         {
         }
 

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -46,7 +46,7 @@ namespace JustEat.StatsD
             var endpointSource = EndpointParser.MakeEndPointSource(
                 configuration.Host, configuration.Port, configuration.DnsLookupInterval);
 
-            var transport = new PooledUdpTransport(endpointSource);
+            var transport = new UdpTransport(endpointSource);
 
             if (configuration.PreferBufferedTransport)
             {

--- a/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
+++ b/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
@@ -128,7 +128,7 @@ namespace JustEat.StatsD
         private static IStatsDTransport ResolveStatsDTransport(IServiceProvider provider)
         {
             var endpointSource = provider.GetRequiredService<IPEndPointSource>();
-            return new PooledUdpTransport(endpointSource);
+            return new UdpTransport(endpointSource);
         }
     }
 }

--- a/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
@@ -38,7 +38,7 @@ namespace JustEat.StatsD
 
             var endpointSource = EndpointParser.MakeEndPointSource(
                 configuration.Host, configuration.Port, configuration.DnsLookupInterval);
-            _transport = new PooledUdpTransport(endpointSource);
+            _transport = new UdpTransport(endpointSource);
             _onError = configuration.OnError;
         }
 

--- a/src/JustEat.StatsD/UdpTransport.cs
+++ b/src/JustEat.StatsD/UdpTransport.cs
@@ -8,21 +8,22 @@ using JustEat.StatsD.EndpointLookups;
 namespace JustEat.StatsD
 {
     /// <summary>
-    /// A class representing an implementation of <see cref="IStatsDTransport"/> uses UDP and pools sockets. This class cannot be inherited.
+    /// A class representing an implementation of <see cref="IStatsDTransport"/>
+    /// that uses UDP and pools sockets. This class cannot be inherited.
     /// </summary>
-    public sealed class PooledUdpTransport : IStatsDTransport, IStatsDBufferedTransport, IDisposable
+    public sealed class UdpTransport : IStatsDTransport, IStatsDBufferedTransport, IDisposable
     {
         private ConnectedSocketPool _pool;
         private readonly IPEndPointSource _endpointSource;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PooledUdpTransport"/> class.
+        /// Initializes a new instance of the <see cref="UdpTransport"/> class.
         /// </summary>
         /// <param name="endPointSource">The <see cref="IPEndPointSource"/> to use.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="endPointSource"/> is <see langword="null"/>.
         /// </exception>
-        public PooledUdpTransport(IPEndPointSource endPointSource)
+        public UdpTransport(IPEndPointSource endPointSource)
         {
             _endpointSource = endPointSource ?? throw new ArgumentNullException(nameof(endPointSource));
         }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Rename `PooledUdpTransport` to `UdpTransport` as it's the only Udp transport.
Rename vars, tests, benchmarks to match.

_Please include a reference to a GitHub issue if appropriate._


Follow-on from #114