### PR TITLE
Remove the "PreferBufferedTransport" flag

### DIFF
--- a/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
+++ b/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
@@ -77,8 +77,7 @@ namespace JustEat.StatsD
             var config = new StatsDConfiguration
             {
                 Prefix = "test",
-                Host = "127.0.0.1",
-                PreferBufferedTransport = true
+                Host = "127.0.0.1"
             };
 
             var transport = new BothVersionsTransportMock();
@@ -97,8 +96,7 @@ namespace JustEat.StatsD
             var config = new StatsDConfiguration
             {
                 Prefix = "test",
-                Host = "127.0.0.1",
-                PreferBufferedTransport = true
+                Host = "127.0.0.1"
             };
 
             var transport = new BothVersionsTransportMock();
@@ -117,8 +115,7 @@ namespace JustEat.StatsD
             var config = new StatsDConfiguration
             {
                 Prefix = "test",
-                Host = "127.0.0.1",
-                PreferBufferedTransport = false
+                Host = "127.0.0.1"
             };
 
             var transport = new Mock<IStatsDTransport>(MockBehavior.Loose);

--- a/src/JustEat.StatsD.Tests/WhenTheTransportThrows.cs
+++ b/src/JustEat.StatsD.Tests/WhenTheTransportThrows.cs
@@ -102,18 +102,9 @@ namespace JustEat.StatsD
                 config => new StringBasedStatsDPublisher(config, new ThrowingTransport())
             },
             {
-                "StatsDPublisher",
-                config =>
-                {
-                    config.PreferBufferedTransport = false;
-                    return new StatsDPublisher(config, new ThrowingTransport());
-                }
-            },
-            {
                 "StatsDPublisherBuffered",
                 config =>
                 {
-                    config.PreferBufferedTransport = true;
                     return new StatsDPublisher(config, new ThrowingTransport());
                 }
             }

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -27,6 +27,12 @@ namespace JustEat.StatsD
         public TimeSpan? DnsLookupInterval { get; set; } = DefaultDnsLookupInterval;
 
         /// <summary>
+        /// Configure to use either UDP or IP sockets to transport stats.
+        /// Default is UDP.
+        /// </summary>
+        public SocketProtocol SocketProtocol { get; set; } = SocketProtocol.Udp;
+
+        /// <summary>
         /// Prepend a prefix to all stats.
         /// Default is empty.
         /// </summary>
@@ -40,19 +46,5 @@ namespace JustEat.StatsD
         /// The default behaviour is to ignore the error
         /// </summary>
         public Func<Exception, bool> OnError { get; set; }
-
-        /// <summary>
-        /// If true will prefer to use <see cref="IStatsDBufferedTransport"/> interface implementation
-        /// if transport implementation provides both 
-        /// <see cref="IStatsDBufferedTransport"/> and <see cref="IStatsDTransport"/> interfaces.
-        /// Default is true.
-        /// </summary>
-        public bool PreferBufferedTransport { get; set; } = true;
-
-        /// <summary>
-        /// Configure to use either UDP or IP sockets to transport stats.
-        /// Default is Udp.
-        /// </summary>
-        public SocketProtocol SocketProtocol { get; set; } = SocketProtocol.Udp;
     }
 }

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -27,7 +27,7 @@ namespace JustEat.StatsD
 
             switch (transport)
             {
-                case IStatsDBufferedTransport bufferedTransport when configuration.PreferBufferedTransport:
+                case IStatsDBufferedTransport bufferedTransport:
                     _inner = new BufferBasedStatsDPublisher(configuration, bufferedTransport);
                     break;
                 default:
@@ -48,14 +48,7 @@ namespace JustEat.StatsD
 
             var transport = new SocketTransport(endpointSource, configuration.SocketProtocol);
 
-            if (configuration.PreferBufferedTransport)
-            {
-                _inner = new BufferBasedStatsDPublisher(configuration, transport);
-            }
-            else
-            {
-                _inner = new StringBasedStatsDPublisher(configuration, transport);
-            }
+            _inner = new BufferBasedStatsDPublisher(configuration, transport);
         }
 
         public void MarkEvent(string name)


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

The "PreferBufferedTransport" flag should always be true. In Version 4.0 we are are removing redundant code paths because 
- we can make breaking changes (although the majority of the consumers should be able to just recompile and carry on) 
- and these "experiments" can be productionised now.  We keep the best/fastest path and drop the rest. The new code is ether ready for mainstream use, or should be made so.

So should the `StatsDPublisher` with an `IStatsDPublisher _inner` also go?
And the distinction between `IStatsDTransport` and `IStatsDBufferedTransport` ?

_Please include a reference to a GitHub issue if appropriate._
