### PR TITLE
Fix localhost handling in DnsLookupIpEndpointSource

### DIFF
--- a/src/JustEat.StatsD.Tests/EndpointLookups/DnsLookupIpEndpointSourceTests.cs
+++ b/src/JustEat.StatsD.Tests/EndpointLookups/DnsLookupIpEndpointSourceTests.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Net.Sockets;
+using Shouldly;
+using Xunit;
+
+namespace JustEat.StatsD.EndpointLookups
+{
+    public static class DnsLookupIpEndpointSourceTests
+    {
+        [Fact]
+        public static void GetEndpointPrefersIPV4WhenHostnameIsLocalhost()
+        {
+            // Arrange
+            var target = new DnsLookupIpEndpointSource("localhost", 8125);
+
+            // Act
+            IPEndPoint actual = target.GetEndpoint();
+
+            // Assert
+            actual.ShouldNotBeNull();
+            actual.AddressFamily.ShouldBe(AddressFamily.InterNetwork);
+            actual.Address.ShouldBe(IPAddress.Parse("127.0.0.1"));
+            actual.Port.ShouldBe(8125);
+        }
+    }
+}

--- a/src/JustEat.StatsD/EndpointLookups/DnsLookupIpEndpointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/DnsLookupIpEndpointSource.cs
@@ -1,5 +1,7 @@
-﻿using System;
+using System;
+using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 
 namespace JustEat.StatsD.EndpointLookups
 {
@@ -31,7 +33,20 @@ namespace JustEat.StatsD.EndpointLookups
             {
                 throw new Exception($"DNS did not find any addresses for statsd host '${hostName}'");
             }
-            return endpoints[0];
+
+            IPAddress result = null;
+
+            if (endpoints.Length > 1)
+            {
+                result = endpoints.FirstOrDefault(p => p.AddressFamily == AddressFamily.InterNetwork);
+            }
+
+            if (result == null)
+            {
+                result = endpoints[0];
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
While investigating writing some integration tests to help avoid issues like #110 in the future and assist with the work for 4.0.0, I found a bug in the DNS handling for `"localhost"`.

If you run statsd locally in the default configuration, it listens at `127.0.0.1:8125` using IPv4.

However, on a machine that supports both IPv4 and IPv6, the first address returned by `Dns.GetHostAddressesAsync()` _may_ be an IPv6 address.

This causes metrics to be sent to `::1` instead of `127.0.0.1`, where there is nothing listening, so metrics are silently dropped. This would found by my integration test as the statsd admin interface on `8126` did not report back that the metrics being sent were being received.

This PR fixes this by preferring the first address with an address family of `AddressFamily.InterNetwork` as that's the intuitive default behaviour for statsd for _"pit-of-success"_.

We _could maybe_ extend things in the future to support preferring IPv6 through configuration, but that's already achievable today by using `SimpleIpEndpoint` instead.