### PR TITLE
Add integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,9 @@ addons:
     - libssl-dev
     - libunwind8
 
+install:
+  - git clone https://github.com/etsy/statsd.git
+  - node ./statsd/stats.jd ./src/JustEat.StatsD.Tests/statsdconfig.js &
+
 script:
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
 
 install:
   - git clone https://github.com/etsy/statsd.git
-  - node ./statsd/stats.jd ./src/JustEat.StatsD.Tests/statsdconfig.js &
+  - node ./statsd/stats.js ./src/JustEat.StatsD.Tests/statsdconfig.js &
 
 script:
   - ./build.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 install:
-  - cmd: git clone https://github.com/etsy/statsd.git
-  - ps: Start-Process "node" -ArgumentList ".\stats.js .\src\JustEat.StatsD.Tests\statsdconfig.js" -WindowStyle Hidden
+  - git clone https://github.com/etsy/statsd.git ..\statsd
+  - ps: Start-Process "node" -ArgumentList "..\statsd\stats.js .\src\JustEat.StatsD.Tests\statsdconfig.js" -WindowStyle Hidden
   - ps: .\SetAppVeyorBuildVersion.ps1
 build_script:
   - ps: .\Build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 install:
+  - ps: git clone https://github.com/etsy/statsd.git
+  - ps: Start-Process "node" -ArgumentList ".\stats.js .\src\JustEat.StatsD.Tests\statsdconfig.js" -WindowStyle Hidden
   - ps: .\SetAppVeyorBuildVersion.ps1
 build_script:
   - ps: .\Build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 install:
-  - ps: git clone https://github.com/etsy/statsd.git 2> $null
+  - cmd: git clone https://github.com/etsy/statsd.git
   - ps: Start-Process "node" -ArgumentList ".\stats.js .\src\JustEat.StatsD.Tests\statsdconfig.js" -WindowStyle Hidden
   - ps: .\SetAppVeyorBuildVersion.ps1
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 install:
-  - ps: git clone https://github.com/etsy/statsd.git
+  - ps: git clone https://github.com/etsy/statsd.git 2> $null
   - ps: Start-Process "node" -ArgumentList ".\stats.js .\src\JustEat.StatsD.Tests\statsdconfig.js" -WindowStyle Hidden
   - ps: .\SetAppVeyorBuildVersion.ps1
 build_script:

--- a/src/JustEat.StatsD.Tests/IntegrationTests.cs
+++ b/src/JustEat.StatsD.Tests/IntegrationTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using Xunit;
+
+namespace JustEat.StatsD
+{
+    public static class IntegrationTests
+    {
+        [SkippableFact]
+        public static async Task Can_Send_Metrics_To_StatsD()
+        {
+            Skip.If(Environment.GetEnvironmentVariable("CI") == null, "By default, this test is only run during continuous integration.");
+
+            // Arrange
+            var config = new StatsDConfiguration
+            {
+                Host = "localhost",
+                Prefix = Guid.NewGuid().ToString().Replace("-", string.Empty)
+            };
+
+            var publisher = new StatsDPublisher(config);
+
+            // Act - Create a counter
+            publisher.Increment("apple");
+
+            // Act - Create and change a counter
+            publisher.Increment("bear");        // 1
+            publisher.Increment(10, "bear");    // 11
+            publisher.Increment(10, 0, "bear"); // 11
+            publisher.Decrement("bear");        // 10
+            publisher.Decrement(5, "bear");     // 5
+            publisher.Decrement(5, 0, "bear");  // 5
+
+            // Act - Mark an event (which is a counter)
+            publisher.MarkEvent("fish");
+
+            // Act - Create a gauge
+            publisher.Gauge(3.141, "circle");
+
+            // Act - Create and change a gauge
+            publisher.Gauge(10, "dog");
+            publisher.Gauge(42, "dog");
+
+            // Act - Create a timer
+            publisher.Timing(123, "elephant");
+            publisher.Timing(TimeSpan.FromSeconds(2), "fox");
+            publisher.Timing(456, 1, "goose");
+            publisher.Timing(TimeSpan.FromSeconds(3.5), 1, "hen");
+
+            // Act - Increment multiple counters
+            publisher.Increment(7, 1, "green", "red"); // 7
+            publisher.Increment(2, 0, "green", "red"); // 7
+            publisher.Decrement(1, 0, "red", "green"); // 7
+            publisher.Decrement(4, 1, "red", "green"); // 3
+
+            // Assert
+            var result = await SendCommandAsync("counters");
+            result.Value<int>(config.Prefix + ".apple").ShouldBe(1);
+            result.Value<int>(config.Prefix + ".bear").ShouldBe(5);
+            result.Value<int>(config.Prefix + ".fish").ShouldBe(1);
+            result.Value<int>(config.Prefix + ".green").ShouldBe(3);
+            result.Value<int>(config.Prefix + ".red").ShouldBe(3);
+
+            result = await SendCommandAsync("gauges");
+            result.Value<double>(config.Prefix + ".circle").ShouldBe(3.141);
+            result.Value<int>(config.Prefix + ".dog").ShouldBe(42);
+
+            result = await SendCommandAsync("timers");
+            result[config.Prefix + ".elephant"].Values<int>().ShouldBe(new[] { 123 });
+            result[config.Prefix + ".fox"].Values<int>().ShouldBe(new[] { 2000 });
+            result[config.Prefix + ".goose"].Values<int>().ShouldBe(new[] { 456 });
+            result[config.Prefix + ".hen"].Values<int>().ShouldBe(new[] { 3500 });
+        }
+
+        private static async Task<JObject> SendCommandAsync(string command)
+        {
+            string json;
+
+            using (var client = new TcpClient())
+            {
+                client.Connect("localhost", 8126);
+
+                byte[] input = Encoding.UTF8.GetBytes(command);
+                byte[] output = new byte[client.ReceiveBufferSize];
+
+                int bytesRead;
+
+                using (var stream = client.GetStream())
+                {
+                    await stream.WriteAsync(input);
+                    bytesRead = await stream.ReadAsync(output);
+                }
+
+                output = output.AsSpan(0, bytesRead).ToArray();
+
+                json = Encoding.UTF8.GetString(output).Replace("END", string.Empty);
+            }
+
+            return JObject.Parse(json);
+        }
+    }
+}

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Shouldly" Version="3.0.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/JustEat.StatsD.Tests/statsdconfig.js
+++ b/src/JustEat.StatsD.Tests/statsdconfig.js
@@ -1,0 +1,5 @@
+{
+  graphiteHost: "",
+  port: 8125,
+  backends: []
+}


### PR DESCRIPTION
Add an integration test that sends metrics to a real statsd instance running locally ([docs](https://github.com/etsy/statsd#installation-and-configuration)) in AppVeyor or Travis, and verifies that the values sent to the server are correct by using the admin endpoint on port `8126` ([docs](https://github.com/etsy/statsd/blob/master/docs/admin_interface.md#statsd-specific-commands)).

A unique random prefix is used so that if you run these tests locally the values don't clash.