### PR TITLE
Implement IDisposable on StatsDPublisher

### DIFF
--- a/src/Benchmark/UdpStatSendingBenchmark.cs
+++ b/src/Benchmark/UdpStatSendingBenchmark.cs
@@ -14,7 +14,7 @@ namespace Benchmark
         private SocketTransport _transport;
         private StringBasedStatsDPublisher _udpSender;
         private BufferBasedStatsDPublisher _bufferBasedStatsDPublisher;
-        private IStatsDPublisher _adaptedStatsDPublisher;
+        private StatsDPublisher _adaptedStatsDPublisher;
 
         [GlobalSetup]
         public void Setup()
@@ -47,7 +47,8 @@ namespace Benchmark
         [GlobalCleanup]
         public void Cleanup()
         {
-            _transport.Dispose();
+            _transport?.Dispose();
+            _adaptedStatsDPublisher?.Dispose();
         }
 
         [Benchmark]

--- a/src/JustEat.StatsD.Tests/IntegrationTests.cs
+++ b/src/JustEat.StatsD.Tests/IntegrationTests.cs
@@ -22,58 +22,59 @@ namespace JustEat.StatsD
                 Prefix = Guid.NewGuid().ToString().Replace("-", string.Empty)
             };
 
-            var publisher = new StatsDPublisher(config);
+            using (var publisher = new StatsDPublisher(config))
+            {
+                // Act - Create a counter
+                publisher.Increment("apple");
 
-            // Act - Create a counter
-            publisher.Increment("apple");
+                // Act - Create and change a counter
+                publisher.Increment("bear");        // 1
+                publisher.Increment(10, "bear");    // 11
+                publisher.Increment(10, 0, "bear"); // 11
+                publisher.Decrement("bear");        // 10
+                publisher.Decrement(5, "bear");     // 5
+                publisher.Decrement(5, 0, "bear");  // 5
 
-            // Act - Create and change a counter
-            publisher.Increment("bear");        // 1
-            publisher.Increment(10, "bear");    // 11
-            publisher.Increment(10, 0, "bear"); // 11
-            publisher.Decrement("bear");        // 10
-            publisher.Decrement(5, "bear");     // 5
-            publisher.Decrement(5, 0, "bear");  // 5
+                // Act - Mark an event (which is a counter)
+                publisher.MarkEvent("fish");
 
-            // Act - Mark an event (which is a counter)
-            publisher.MarkEvent("fish");
+                // Act - Create a gauge
+                publisher.Gauge(3.141, "circle");
 
-            // Act - Create a gauge
-            publisher.Gauge(3.141, "circle");
+                // Act - Create and change a gauge
+                publisher.Gauge(10, "dog");
+                publisher.Gauge(42, "dog");
 
-            // Act - Create and change a gauge
-            publisher.Gauge(10, "dog");
-            publisher.Gauge(42, "dog");
+                // Act - Create a timer
+                publisher.Timing(123, "elephant");
+                publisher.Timing(TimeSpan.FromSeconds(2), "fox");
+                publisher.Timing(456, 1, "goose");
+                publisher.Timing(TimeSpan.FromSeconds(3.5), 1, "hen");
 
-            // Act - Create a timer
-            publisher.Timing(123, "elephant");
-            publisher.Timing(TimeSpan.FromSeconds(2), "fox");
-            publisher.Timing(456, 1, "goose");
-            publisher.Timing(TimeSpan.FromSeconds(3.5), 1, "hen");
+                // Act - Increment multiple counters
+                publisher.Increment(7, 1, "green", "red"); // 7
+                publisher.Increment(2, 0, "green", "red"); // 7
+                publisher.Decrement(1, 0, "red", "green"); // 7
+                publisher.Decrement(4, 1, "red", "green"); // 3
 
-            // Act - Increment multiple counters
-            publisher.Increment(7, 1, "green", "red"); // 7
-            publisher.Increment(2, 0, "green", "red"); // 7
-            publisher.Decrement(1, 0, "red", "green"); // 7
-            publisher.Decrement(4, 1, "red", "green"); // 3
+                // Assert
+                var result = await SendCommandAsync("counters");
+                result.Value<int>(config.Prefix + ".apple").ShouldBe(1);
+                result.Value<int>(config.Prefix + ".bear").ShouldBe(5);
+                result.Value<int>(config.Prefix + ".fish").ShouldBe(1);
+                result.Value<int>(config.Prefix + ".green").ShouldBe(3);
+                result.Value<int>(config.Prefix + ".red").ShouldBe(3);
 
-            // Assert
-            var result = await SendCommandAsync("counters");
-            result.Value<int>(config.Prefix + ".apple").ShouldBe(1);
-            result.Value<int>(config.Prefix + ".bear").ShouldBe(5);
-            result.Value<int>(config.Prefix + ".fish").ShouldBe(1);
-            result.Value<int>(config.Prefix + ".green").ShouldBe(3);
-            result.Value<int>(config.Prefix + ".red").ShouldBe(3);
+                result = await SendCommandAsync("gauges");
+                result.Value<double>(config.Prefix + ".circle").ShouldBe(3.141);
+                result.Value<int>(config.Prefix + ".dog").ShouldBe(42);
 
-            result = await SendCommandAsync("gauges");
-            result.Value<double>(config.Prefix + ".circle").ShouldBe(3.141);
-            result.Value<int>(config.Prefix + ".dog").ShouldBe(42);
-
-            result = await SendCommandAsync("timers");
-            result[config.Prefix + ".elephant"].Values<int>().ShouldBe(new[] { 123 });
-            result[config.Prefix + ".fox"].Values<int>().ShouldBe(new[] { 2000 });
-            result[config.Prefix + ".goose"].Values<int>().ShouldBe(new[] { 456 });
-            result[config.Prefix + ".hen"].Values<int>().ShouldBe(new[] { 3500 });
+                result = await SendCommandAsync("timers");
+                result[config.Prefix + ".elephant"].Values<int>().ShouldBe(new[] { 123 });
+                result[config.Prefix + ".fox"].Values<int>().ShouldBe(new[] { 2000 });
+                result[config.Prefix + ".goose"].Values<int>().ShouldBe(new[] { 456 });
+                result[config.Prefix + ".hen"].Values<int>().ShouldBe(new[] { 3500 });
+            }
         }
 
         private static async Task<JObject> SendCommandAsync(string command)

--- a/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
+++ b/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
@@ -1,5 +1,4 @@
 using System;
-using JustEat.StatsD.Buffered;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -83,9 +82,10 @@ namespace JustEat.StatsD
 
             var transport = new BothVersionsTransportMock();
 
-            var publisher = new StatsDPublisher(config, transport);
-
-            publisher.MarkEvent("test");
+            using (var publisher = new StatsDPublisher(config, transport))
+            {
+                publisher.MarkEvent("test");
+            }
 
             transport.BufferedCalls.ShouldBe(1);
             transport.StringCalls.ShouldBe(0);
@@ -103,9 +103,10 @@ namespace JustEat.StatsD
 
             var transport = new BothVersionsTransportMock();
 
-            var publisher = new StatsDPublisher(config, transport);
-
-            publisher.MarkEvent("test");
+            using (var publisher = new StatsDPublisher(config, transport))
+            {
+                publisher.MarkEvent("test");
+            }
 
             transport.BufferedCalls.ShouldBe(1);
             transport.StringCalls.ShouldBe(0);
@@ -123,9 +124,10 @@ namespace JustEat.StatsD
 
             var transport = new Mock<IStatsDTransport>(MockBehavior.Loose);
 
-            var publisher = new StatsDPublisher(config, transport.Object);
-
-            publisher.MarkEvent("test");
+            using (var publisher = new StatsDPublisher(config, transport.Object))
+            {
+                publisher.MarkEvent("test");
+            }
 
             transport.Verify(x => x.Send(It.IsAny<string>()), Times.Once);
         }

--- a/src/JustEat.StatsD.Tests/WhenTheTransportThrows.cs
+++ b/src/JustEat.StatsD.Tests/WhenTheTransportThrows.cs
@@ -31,7 +31,17 @@ namespace JustEat.StatsD
 
             var publisher = factory(validConfig);
 
-            publisher.Increment("anyStat");
+            try
+            {
+                publisher.Increment("anyStat");
+            }
+            finally
+            {
+                if (publisher is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
         }
 
         [Theory]
@@ -43,7 +53,17 @@ namespace JustEat.StatsD
 
             var publisher = factory(validConfig);
 
-            publisher.Increment("anyStat");
+            try
+            {
+                publisher.Increment("anyStat");
+            }
+            finally
+            {
+                if (publisher is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
         }
 
         [Theory]
@@ -55,7 +75,17 @@ namespace JustEat.StatsD
 
             var publisher = factory(validConfig);
 
-            publisher.Increment("anyStat");
+            try
+            {
+                publisher.Increment("anyStat");
+            }
+            finally
+            {
+                if (publisher is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
         }
 
         [Theory]
@@ -67,8 +97,18 @@ namespace JustEat.StatsD
 
             var publisher = factory(validConfig);
 
-            Should.Throw<SocketException>(() =>
-                publisher.Increment("anyStat"));
+            try
+            {
+                Should.Throw<SocketException>(() =>
+                    publisher.Increment("anyStat"));
+            }
+            finally
+            {
+                if (publisher is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
         }
 
         [Theory]
@@ -85,9 +125,19 @@ namespace JustEat.StatsD
 
             var publisher = factory(validConfig);
 
-            capturedEx.ShouldBeNull();
-            publisher.Increment("anyStat");
-            capturedEx.ShouldNotBeNull();
+            try
+            {
+                capturedEx.ShouldBeNull();
+                publisher.Increment("anyStat");
+                capturedEx.ShouldNotBeNull();
+            }
+            finally
+            {
+                if (publisher is IDisposable disposable)
+                {
+                    disposable.Dispose();
+                }
+            }
         }
 
         public static TheoryData<string, Func<StatsDConfiguration, IStatsDPublisher>> Publishers =>

--- a/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
@@ -21,11 +21,6 @@ namespace JustEat.StatsD.Buffered
 
         public BufferBasedStatsDPublisher(StatsDConfiguration configuration, IStatsDBufferedTransport transport)
         {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
             _onError = configuration.OnError;
             _transport = transport;
             _formatter = new StatsDUtf8Formatter(configuration.Prefix);

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -5,8 +5,12 @@ using JustEat.StatsD.EndpointLookups;
 namespace JustEat.StatsD
 {
     /// <summary>
-    ///     Will synchronously publish stats at statsd as you make calls; will not batch sends.
+    /// A class representing the default implementation of <see cref="IStatsDPublisher"/> that
+    /// publishes counters, gauges and timers to statsD. This class cannot be inherited.
     /// </summary>
+    /// <remarks>
+    /// Metrics are published synchronously immediately and are not batched.
+    /// </remarks>
     public sealed class StatsDPublisher : IStatsDPublisher, IDisposable
     {
         private readonly IStatsDPublisher _inner;
@@ -15,6 +19,17 @@ namespace JustEat.StatsD
         private bool _disposed;
         private bool _disposeTransport;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatsDPublisher"/> class for the specified transport.
+        /// </summary>
+        /// <param name="configuration">The statsD configuration to use.</param>
+        /// <param name="transport">The transport implementation to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="configuration"/> or <paramref name="transport"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="configuration"/> is invalid, such as an invalid hostname or IP address.
+        /// </exception>
         public StatsDPublisher(StatsDConfiguration configuration, IStatsDTransport transport)
         {
             if (configuration == null)
@@ -41,6 +56,16 @@ namespace JustEat.StatsD
             _disposeTransport = false;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatsDPublisher"/> class using the default transport.
+        /// </summary>
+        /// <param name="configuration">The statsD configuration to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="configuration"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="configuration"/> is invalid, such as an invalid hostname or IP address.
+        /// </exception>
         public StatsDPublisher(StatsDConfiguration configuration)
         {
             if (configuration == null)
@@ -66,81 +91,97 @@ namespace JustEat.StatsD
             }
         }
 
+        /// <inheritdoc />
         public void MarkEvent(string name)
         {
             _inner.MarkEvent(name);
         }
 
+        /// <inheritdoc />
         public void Increment(string bucket)
         {
             _inner.Increment(bucket);
         }
 
+        /// <inheritdoc />
         public void Increment(long value, string bucket)
         {
             _inner.Increment(value, bucket);
         }
 
+        /// <inheritdoc />
         public void Increment(long value, double sampleRate, string bucket)
         {
             _inner.Increment(value, sampleRate, bucket);
         }
 
+        /// <inheritdoc />
         public void Increment(long value, double sampleRate, params string[] buckets)
         {
             _inner.Increment(value, sampleRate, buckets);
         }
 
+        /// <inheritdoc />
         public void Decrement(string bucket)
         {
             _inner.Decrement(bucket);
         }
 
+        /// <inheritdoc />
         public void Decrement(long value, string bucket)
         {
             _inner.Decrement(value, bucket);
         }
 
+        /// <inheritdoc />
         public void Decrement(long value, double sampleRate, string bucket)
         {
             _inner.Decrement(value, sampleRate, bucket);
         }
 
+        /// <inheritdoc />
         public void Decrement(long value, double sampleRate, params string[] buckets)
         {
             _inner.Decrement(value, sampleRate, buckets);
         }
 
+        /// <inheritdoc />
         public void Gauge(double value, string bucket)
         {
             _inner.Gauge(value, bucket);
         }
 
+        /// <inheritdoc />
         public void Gauge(long value, string bucket)
         {
             _inner.Gauge(value, bucket);
         }
 
+        /// <inheritdoc />
         public void Timing(TimeSpan duration, string bucket)
         {
             _inner.Timing(duration, bucket);
         }
 
+        /// <inheritdoc />
         public void Timing(TimeSpan duration, double sampleRate, string bucket)
         {
             _inner.Timing(duration, sampleRate, bucket);
         }
 
+        /// <inheritdoc />
         public void Timing(long duration, string bucket)
         {
             _inner.Timing(duration, bucket);
         }
 
+        /// <inheritdoc />
         public void Timing(long duration, double sampleRate, string bucket)
         {
             _inner.Timing(duration, sampleRate, bucket);
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             if (!_disposed)

--- a/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
@@ -11,13 +11,7 @@ namespace JustEat.StatsD
 
         public StringBasedStatsDPublisher(StatsDConfiguration configuration, IStatsDTransport transport)
         {
-            if (configuration == null)
-            {
-               throw new ArgumentNullException(nameof(configuration));
-            }
-
-            _transport = transport ?? throw new ArgumentNullException(nameof(transport));
-
+            _transport = transport;
             _formatter = new StatsDMessageFormatter(configuration.Prefix);
             _onError = configuration.OnError;
         }


### PR DESCRIPTION
  * Make the `StatsDPublisher` class `IDisposable` to fix #119.
  * Change `StatsDPublisher` to be `sealed` as there are no useful extension points and would otherwise require a finalizer and a `protected virtual void Dispose(bool disposing)` method for `IDisposable` implementation for any derived classes.
  * Remove redundant ReSharper warning comment from #104.
  * Remove some redundant null checks on some internal types.
  * Add XML `///` documentation to `StatsDPublisher`.
