### PR TITLE
Add static analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,10 @@
  <Import Project="version.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" PrivateAssets="All" />
+    <PackageReference Include="Text.Analyzers" Version="2.6.2" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -1,20 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
+    <NoWarn>$(NoWarn);CA1001;CA1822</NoWarn>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\JustEat.StatsD\JustEat.StatsD.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -75,19 +75,7 @@ namespace JustEat.StatsD.Extensions
             BucketNames.Add(bucket);
         }
 
-        public void Gauge(double value, string bucket, DateTime timestamp)
-        {
-            CallCount++;
-            BucketNames.Add(bucket);
-        }
-
         public void Gauge(long value, string bucket)
-        {
-            CallCount++;
-            BucketNames.Add(bucket);
-        }
-
-        public void Gauge(long value, string bucket, DateTime timestamp)
         {
             CallCount++;
             BucketNames.Add(bucket);

--- a/src/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Threading;
 using Shouldly;
 using Xunit;
 
 namespace JustEat.StatsD.Extensions
 {
-    public class SimpleTimerStatNameTests
+    public static class SimpleTimerStatNameTests
     {
         [Fact]
         public static void DefaultIsToKeepStatName()

--- a/src/JustEat.StatsD.Tests/IntegrationTests.cs
+++ b/src/JustEat.StatsD.Tests/IntegrationTests.cs
@@ -19,7 +19,7 @@ namespace JustEat.StatsD
             var config = new StatsDConfiguration
             {
                 Host = "localhost",
-                Prefix = Guid.NewGuid().ToString().Replace("-", string.Empty)
+                Prefix = Guid.NewGuid().ToString().Replace("-", string.Empty, StringComparison.Ordinal)
             };
 
             var publisher = new StatsDPublisher(config);
@@ -97,7 +97,7 @@ namespace JustEat.StatsD
 
                 output = output.AsSpan(0, bytesRead).ToArray();
 
-                json = Encoding.UTF8.GetString(output).Replace("END", string.Empty);
+                json = Encoding.UTF8.GetString(output).Replace("END", string.Empty, StringComparison.Ordinal);
             }
 
             return JObject.Parse(json);

--- a/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/src/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -1,5 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <NoWarn>$(NoWarn);CA1707;CA2007</NoWarn>
     <RootNamespace>JustEat.StatsD</RootNamespace>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>

--- a/src/JustEat.StatsD.Tests/SocketTransportTests.cs
+++ b/src/JustEat.StatsD.Tests/SocketTransportTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace JustEat.StatsD
 {
-    public class SocketTransportTests
+    public static class SocketTransportTests
     {
         [Fact]
         public static void ValidSocketTransportCanBeConstructed()
@@ -35,16 +35,21 @@ namespace JustEat.StatsD
         [Fact]
         public static void NullEndpointSourceThrowsInConstructor()
         {
-            Should.Throw<ArgumentNullException>(
+            Assert.Throws<ArgumentNullException>(
+                "endPointSource",
                 () => new SocketTransport(null, SocketProtocol.IP));
-
         }
 
         [Fact]
         public static void InvalidSocketProtocolThrowsInConstructor()
         {
-            Should.Throw<ArgumentOutOfRangeException>(
-                () => new SocketTransport(LocalStatsEndpoint(), (SocketProtocol)42));
+            SocketProtocol socketProtocol = (SocketProtocol)42;
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(
+                "socketProtocol",
+                () => new SocketTransport(LocalStatsEndpoint(), socketProtocol));
+
+            exception.ActualValue.ShouldBe(socketProtocol);
         }
 
         private static IPEndPointSource LocalStatsEndpoint()

--- a/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
+++ b/src/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
@@ -1,5 +1,4 @@
 using System;
-using JustEat.StatsD.Buffered;
 using Moq;
 using Shouldly;
 using Xunit;
@@ -37,22 +36,24 @@ namespace JustEat.StatsD
         [Fact]
         public void ConfigurationIsNull()
         {
-            StatsDConfiguration noConfig = null;
+            StatsDConfiguration configuration = null;
 
-            Should.Throw<ArgumentNullException>(
-             () => new StringBasedStatsDPublisher(noConfig));
+            Assert.Throws<ArgumentNullException>(
+                "configuration",
+                () => new StringBasedStatsDPublisher(configuration));
         }
 
         [Fact]
         public void ConfigurationHasNoHost()
         {
-            var badConfig = new StatsDConfiguration
+            var configuration = new StatsDConfiguration
             {
                 Host = null
             };
 
-            Should.Throw<ArgumentNullException>(
-             () => new StringBasedStatsDPublisher(badConfig));
+            Assert.Throws<ArgumentException>(
+                "configuration",
+                () => new StringBasedStatsDPublisher(configuration));
         }
 
         private class BothVersionsTransportMock : IStatsDTransport, IStatsDBufferedTransport

--- a/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
+++ b/src/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
@@ -1,6 +1,5 @@
 #if !NET451
 using System;
-using System.Collections.Generic;
 using JustEat.StatsD.EndpointLookups;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -328,20 +327,21 @@ namespace JustEat.StatsD
             public string StatsDHost { get; set; }
         }
 
+#pragma warning disable CA1812 // Instantiated via DI
         private sealed class MyTransport : IStatsDTransport
         {
+
+#pragma warning disable CA1801 // Used to validate that IPEndPointSource is in DI
             public MyTransport(IPEndPointSource endpointSource)
             {
             }
+#pragma warning restore CA1801
 
             public void Send(string metric)
             {
             }
-
-            public void Send(IEnumerable<string> metrics)
-            {
-            }
         }
+#pragma warning restore CA1812
     }
 }
 #endif

--- a/src/JustEat.StatsD.Tests/WhenTheTransportThrows.cs
+++ b/src/JustEat.StatsD.Tests/WhenTheTransportThrows.cs
@@ -31,7 +31,7 @@ namespace JustEat.StatsD
 
             var publisher = factory(validConfig);
 
-            publisher.Increment("anyStat");
+            publisher.Increment(name);
         }
 
         [Theory]
@@ -43,7 +43,7 @@ namespace JustEat.StatsD
 
             var publisher = factory(validConfig);
 
-            publisher.Increment("anyStat");
+            publisher.Increment(name);
         }
 
         [Theory]
@@ -55,7 +55,7 @@ namespace JustEat.StatsD
 
             var publisher = factory(validConfig);
 
-            publisher.Increment("anyStat");
+            publisher.Increment(name);
         }
 
         [Theory]
@@ -68,7 +68,7 @@ namespace JustEat.StatsD
             var publisher = factory(validConfig);
 
             Should.Throw<SocketException>(() =>
-                publisher.Increment("anyStat"));
+                publisher.Increment(name));
         }
 
         [Theory]
@@ -86,7 +86,7 @@ namespace JustEat.StatsD
             var publisher = factory(validConfig);
 
             capturedEx.ShouldBeNull();
-            publisher.Increment("anyStat");
+            publisher.Increment(name);
             capturedEx.ShouldNotBeNull();
         }
 

--- a/src/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
+++ b/src/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
@@ -9,9 +9,12 @@ namespace JustEat.StatsD
     [Collection("ActiveUdpListeners")]
     public class WhenUsingUdpTransport 
     {
+
+#pragma warning disable CA1801 // Used to force the creation of the collection
         public WhenUsingUdpTransport(UdpListeners _)
         {
         }
+#pragma warning restore CA1801
 
         [Fact]
         public void AMetricCanBeSentWithoutAnExceptionBeingThrown()

--- a/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
@@ -93,19 +93,9 @@ namespace JustEat.StatsD.Buffered
             SendMessage(DefaultSampleRate, StatsDMessage.Gauge(value, bucket));
         }
 
-        public void Gauge(double value, string bucket, DateTime timestamp)
-        {
-            Gauge(value, bucket);
-        }
-
         public void Gauge(long value, string bucket)
         {
             Gauge((double) value, bucket);
-        }
-
-        public void Gauge(long value, string bucket, DateTime timestamp)
-        {
-            Gauge(value, bucket);
         }
 
         public void Timing(TimeSpan duration, string bucket)

--- a/src/JustEat.StatsD/Buffered/StatsDUtf8Formatter.cs
+++ b/src/JustEat.StatsD/Buffered/StatsDUtf8Formatter.cs
@@ -10,7 +10,13 @@ namespace JustEat.StatsD.Buffered
 
         public StatsDUtf8Formatter(string prefix)
         {
-            _utf8Prefix = string.IsNullOrWhiteSpace(prefix) ? new byte[0] : Encoding.UTF8.GetBytes(prefix + ".");
+            _utf8Prefix = string.IsNullOrWhiteSpace(prefix) ?
+#if NET451
+                new byte[0] :
+#else
+                Array.Empty<byte>() :
+#endif
+                Encoding.UTF8.GetBytes(prefix + ".");
         }
 
         public int GetMaxBufferSize(in StatsDMessage msg)

--- a/src/JustEat.StatsD/DisposableTimer.cs
+++ b/src/JustEat.StatsD/DisposableTimer.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace JustEat.StatsD
 {
-    internal class DisposableTimer : IDisposableTimer
+    internal sealed class DisposableTimer : IDisposableTimer
     {
         private bool _disposed;
 

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -123,7 +123,7 @@ namespace JustEat.StatsD
             return Increment(name);
         }
 
-        private string Format(double sampleRate, string stat)
+        private static string Format(double sampleRate, string stat)
         {
             if (sampleRate >= DefaultSampleRate)
             {
@@ -138,7 +138,7 @@ namespace JustEat.StatsD
             return string.Empty;
         }
 
-        private string Format(double sampleRate, params string[] stats)
+        private static string Format(double sampleRate, params string[] stats)
         {
             var formatted = new StringBuilder();
             if (sampleRate < DefaultSampleRate)

--- a/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
@@ -31,7 +31,7 @@ namespace JustEat.StatsD
 
             if (string.IsNullOrWhiteSpace(configuration.Host))
             {
-                throw new ArgumentNullException(nameof(configuration.Host));
+                throw new ArgumentException("No hostname is set.", nameof(configuration));
             }
 
             _formatter = new StatsDMessageFormatter(configuration.Prefix);

--- a/src/JustEat.StatsD/TimerExtensions.cs
+++ b/src/JustEat.StatsD/TimerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace JustEat.StatsD
@@ -40,7 +40,7 @@ namespace JustEat.StatsD
         {
             using (var timer = StartTimer(publisher, bucket))
             {
-                await action(timer);
+                await action(timer).ConfigureAwait(false);
             }
         }
 
@@ -69,7 +69,7 @@ namespace JustEat.StatsD
         {
             using (var timer = StartTimer(publisher, bucket))
             {
-                return await func(timer);
+                return await func(timer).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
This PR adds Roslyn code analyzers (a bit like FxCop of old) that run at build time. It also fixes various issues identified by them including:
  1. Redundant methods caused by changes to `IStatsDPublisher` over time.
  1. Changes methods that don't use instance data to be static.
  1. Makes the internal `DisposableTimer` class sealed.
  1. Fixes an incorrectly setup exception for parameter validation.
  1. Uses `Array.Empty<T>()` to save an allocation in target frameworks that support it.
  1. Specifies `ConfigureAwait(false)` when awaiting tasks.