### PR TITLE
Fix unbuffered batch metrics send

### DIFF
--- a/src/JustEat.StatsD.Tests/StringBasedStatsDPublisherTests.cs
+++ b/src/JustEat.StatsD.Tests/StringBasedStatsDPublisherTests.cs
@@ -1,0 +1,89 @@
+using System;
+using Moq;
+using Xunit;
+
+namespace JustEat.StatsD
+{
+    public static class StringBasedStatsDPublisherTests
+    {
+        [Fact]
+        public static void Decrement_Sends_Multiple_Metrics()
+        {
+            // Arrange
+            var mock = new Mock<IStatsDTransport>();
+
+            var config = new StatsDConfiguration
+            {
+                Prefix = "red",
+            };
+
+            var publisher = new StringBasedStatsDPublisher(config, mock.Object);
+
+            // Act
+            publisher.Decrement(10, 1, "white", "blue");
+
+            // Assert
+            mock.Verify((p) => p.Send("red.white:-10|c"), Times.Once());
+            mock.Verify((p) => p.Send("red.blue:-10|c"), Times.Once());
+        }
+
+        [Fact]
+        public static void Increment_Sends_Multiple_Metrics()
+        {
+            // Arrange
+            var mock = new Mock<IStatsDTransport>();
+
+            var config = new StatsDConfiguration
+            {
+                Prefix = "red",
+            };
+
+            var publisher = new StringBasedStatsDPublisher(config, mock.Object);
+
+            // Act
+            publisher.Increment(10, 1, "white", "blue");
+
+            // Assert
+            mock.Verify((p) => p.Send("red.white:10|c"), Times.Once());
+            mock.Verify((p) => p.Send("red.blue:10|c"), Times.Once());
+        }
+
+        [Fact]
+        public static void Metrics_Not_Sent_If_Array_Is_Null_Or_Empty()
+        {
+            // Arrange
+            var mock = new Mock<IStatsDTransport>();
+            var config = new StatsDConfiguration();
+
+            var publisher = new StringBasedStatsDPublisher(config, mock.Object);
+
+            // Act
+            publisher.Decrement(1, 1, null as string[]);
+            publisher.Increment(1, 1, null as string[]);
+            publisher.Decrement(1, 1, Array.Empty<string>());
+            publisher.Increment(1, 1, Array.Empty<string>());
+            publisher.Decrement(1, 1, new[] { string.Empty });
+            publisher.Increment(1, 1, new[] { string.Empty });
+
+            // Assert
+            mock.Verify((p) => p.Send(It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public static void Metrics_Not_Sent_If_No_Metrics()
+        {
+            // Arrange
+            var mock = new Mock<IStatsDTransport>();
+            var config = new StatsDConfiguration();
+
+            var publisher = new StringBasedStatsDPublisher(config, mock.Object);
+
+            // Act
+            publisher.Decrement(1, 0, new[] { "foo" });
+            publisher.Increment(1, 0, new[] { "bar" });
+
+            // Assert
+            mock.Verify((p) => p.Send(It.IsAny<string>()), Times.Never());
+        }
+    }
+}

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -16,15 +16,17 @@ namespace JustEat.StatsD
         private readonly string _prefix;
 
         public StatsDMessageFormatter()
-            : this(string.Empty) {}
+            : this(string.Empty)
+        {
+        }
 
-            public StatsDMessageFormatter(string prefix)
+        public StatsDMessageFormatter(string prefix)
         {
             _prefix = prefix;
 
             if (!string.IsNullOrWhiteSpace(_prefix))
             {
-                _prefix = _prefix + "."; // if we have something, then append a . to it to make concatenations easy.
+                _prefix = _prefix + "."; // If we have something, then append a '.' to it to make concatenations easy.
             }
         }
 
@@ -50,7 +52,6 @@ namespace JustEat.StatsD
         {
             return Decrement(magnitude, DefaultSampleRate, statBucket);
         }
-
 
         public string Decrement(long magnitude, double sampleRate, string statBucket)
         {

--- a/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/StringBasedStatsDPublisher.cs
@@ -59,7 +59,18 @@ namespace JustEat.StatsD
 
         public void Increment(long value, double sampleRate, params string[] buckets)
         {
-            Send(_formatter.Increment(value, sampleRate, buckets));
+            if (buckets == null || buckets.Length == 0)
+            {
+                return;
+            }
+
+            foreach (string bucket in buckets)
+            {
+                if (!string.IsNullOrEmpty(bucket))
+                {
+                    Send(_formatter.Increment(value, sampleRate, bucket));
+                }
+            }
         }
 
         public void Decrement(string bucket)
@@ -79,7 +90,18 @@ namespace JustEat.StatsD
 
         public void Decrement(long value, double sampleRate, params string[] buckets)
         {
-            Send(_formatter.Decrement(value, sampleRate, buckets));
+            if (buckets == null || buckets.Length == 0)
+            {
+                return;
+            }
+
+            foreach (string bucket in buckets)
+            {
+                if (!string.IsNullOrEmpty(bucket))
+                {
+                    Send(_formatter.Decrement(value, sampleRate, bucket));
+                }
+            }
         }
 
         public void Gauge(double  value, string bucket)
@@ -119,6 +141,11 @@ namespace JustEat.StatsD
 
         private void Send(string metric)
         {
+            if (metric.Length == 0)
+            {
+                return;
+            }
+
             try
             {
                 _transport.Send(metric);


### PR DESCRIPTION
When I added more integration tests in #127, it found a bug where multiple metrics being sent at once using the "old" implementation (the existing one at the time of #104) would be malformed and dropped when sent to statsd.

This PR fixes that by making the following changes and optimisations uncovered while debugging the failing tests:
  1. Fix malformed metrics by sending multiple metrics as different sends, not one send with everything concatenated together. It may be that this is allowed, but I couldn't find what the delimiter would be in that scenario, so I just switched to a `foreach` liked the buffered implementation does.
  1. Add optimisations to not send empty strings to statsd if the sample rate means that none of the metrics need to be sent.
  1. Add null and zero check for buckets array to fix potential for a `NullReferenceException` as well as removing the need to allocate an enumerator.

I guess that we should include this with #124 and do a `3.2.2` release with the fix?
