### PR TITLE
review SocketTransport

### DIFF
--- a/src/JustEat.StatsD/SocketTransport.cs
+++ b/src/JustEat.StatsD/SocketTransport.cs
@@ -64,6 +64,7 @@ namespace JustEat.StatsD
         public void Dispose()
         {
             _pool?.Dispose();
+            _pool = null;
         }
 
         private ConnectedSocketPool GetPool(IPEndPoint endPoint)


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

review of `SocketTransport` as in an earlier closed PR ( #132 ) . 

Don't hold on to a disposed pool instance, it's not in a state were it can be used.  This also make the `Dispose` method safer, since a second call to it will do no additional work.

_Please include a reference to a GitHub issue if appropriate._
