### PR TITLE
use the sync version of GetHostAddresses

### DIFF
--- a/src/JustEat.StatsD/EndpointLookups/DnsLookupIpEndpointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/DnsLookupIpEndpointSource.cs
@@ -26,8 +26,7 @@ namespace JustEat.StatsD.EndpointLookups
 
         private static IPAddress GetIpAddressOfHost(string hostName)
         {
-            var endpoints = Dns.GetHostAddressesAsync(hostName)
-                .GetAwaiter().GetResult();
+            var endpoints = Dns.GetHostAddresses(hostName);
 
             if (endpoints == null || endpoints.Length == 0)
             {


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Use the sync version of `GetHostAddresses` instead of `GetHostAddressesAsync`.

We had to (ab)use [the async version of `GetHostAddresses` back when targeting NetStandard 1.6](https://apisof.net/catalog/System.Net.Dns.GetHostAddressesAsync(String))
it is really hard to make this code async, as it will touch everything right up to the common case of sending stats, and the disposable timers, all to cater for a corner case.


But it seems that [the sync version of `GetHostAddresses` came back in NetStandard 2.0](https://apisof.net/catalog/System.Net.Dns.GetHostAddresses(String)).
And we had not noticed.


_Please include a reference to a GitHub issue if appropriate._
