### PR TITLE
Simplify IStatsDPublisher

### DIFF
--- a/src/Benchmark/StatSendingBenchmark.cs
+++ b/src/Benchmark/StatSendingBenchmark.cs
@@ -41,7 +41,7 @@ namespace Benchmark
         [Benchmark]
         public void RunIp()
         {
-            _ipSender.MarkEvent("hello.i");
+            _ipSender.Increment("hello.i");
             _ipSender.Increment(20, "increment.i");
             _ipSender.Timing(Timed, "timer.i");
             _ipSender.Gauge(354654, "gauge.i");
@@ -58,7 +58,7 @@ namespace Benchmark
         [Benchmark]
         public void RunUdp()
         {
-            _udpSender.MarkEvent("hello.u");
+            _udpSender.Increment("hello.u");
             _udpSender.Increment(20, "increment.u");
             _udpSender.Timing(Timed, "timer.u");
             _udpSender.Gauge(354654, "gauge.u");

--- a/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -5,32 +5,22 @@ namespace JustEat.StatsD.Extensions
 {
     public class FakeStatsPublisher : IStatsDPublisher
     {
-        public int CallCount { get; set; }
-        public int DisposeCount { get; set; }
-        public TimeSpan LastDuration { get; set; }
-
-        public List<string> BucketNames { get; private set; }
-
         public FakeStatsPublisher()
         {
             BucketNames = new List<string>();
         }
 
+        public int CallCount { get; set; }
+
+        public int DisposeCount { get; set; }
+
+        public TimeSpan LastDuration { get; set; }
+
+        public List<string> BucketNames { get; private set; }
+
         public void Dispose()
         {
             DisposeCount++;
-        }
-
-        public void Increment(string bucket)
-        {
-            CallCount++;
-            BucketNames.Add(bucket);
-        }
-
-        public void Increment(long value, string bucket)
-        {
-            CallCount++;
-            BucketNames.Add(bucket);
         }
 
         public void Increment(long value, double sampleRate, string bucket)
@@ -39,66 +29,9 @@ namespace JustEat.StatsD.Extensions
             BucketNames.Add(bucket);
         }
 
-        public void Increment(long value, double sampleRate, params string[] buckets)
-        {
-            CallCount++;
-            BucketNames.AddRange(buckets);
-        }
-
-        public void Decrement(string bucket)
-        {
-            CallCount++;
-            BucketNames.Add(bucket);
-        }
-
-        public void Decrement(long value, string bucket)
-        {
-            CallCount++;
-            BucketNames.Add(bucket);
-        }
-
-        public void Decrement(long value, double sampleRate, string bucket)
-        {
-            CallCount++;
-            BucketNames.Add(bucket);
-        }
-
-        public void Decrement(long value, double sampleRate, params string[] buckets)
-        {
-            CallCount++;
-            BucketNames.AddRange(buckets);
-        }
-
         public void Gauge(double value, string bucket)
         {
             CallCount++;
-            BucketNames.Add(bucket);
-        }
-
-        public void Gauge(long value, string bucket)
-        {
-            CallCount++;
-            BucketNames.Add(bucket);
-        }
-
-        public void Timing(TimeSpan duration, string bucket)
-        {
-            CallCount++;
-            LastDuration = duration;
-            BucketNames.Add(bucket);
-        }
-
-        public void Timing(TimeSpan duration, double sampleRate, string bucket)
-        {
-            CallCount++;
-            LastDuration = duration;
-            BucketNames.Add(bucket);
-        }
-
-        public void Timing(long duration, string bucket)
-        {
-            CallCount++;
-            LastDuration = TimeSpan.FromMilliseconds(duration);
             BucketNames.Add(bucket);
         }
 
@@ -107,12 +40,6 @@ namespace JustEat.StatsD.Extensions
             CallCount++;
             LastDuration = TimeSpan.FromMilliseconds(duration);
             BucketNames.Add(bucket);
-        }
-
-        public void MarkEvent(string name)
-        {
-            CallCount++;
-            BucketNames.Add(name);
         }
     }
 }

--- a/src/JustEat.StatsD.Tests/IntegrationTests.cs
+++ b/src/JustEat.StatsD.Tests/IntegrationTests.cs
@@ -50,7 +50,7 @@ namespace JustEat.StatsD
             publisher.Decrement(5, 0, "bear");  // 5
 
             // Act - Mark an event (which is a counter)
-            publisher.MarkEvent("fish");
+            publisher.Increment("fish");
 
             // Act - Create a gauge
             publisher.Gauge(3.141, "circle");

--- a/src/JustEat.StatsD.Tests/WhenUsingBufferBasedPublisher.cs
+++ b/src/JustEat.StatsD.Tests/WhenUsingBufferBasedPublisher.cs
@@ -29,7 +29,7 @@ namespace JustEat.StatsD
 
             var fakeTransport = new FakeTransport();
             var publisher = new BufferBasedStatsDPublisher(config, fakeTransport);
-            publisher.MarkEvent(new string(ch, count));
+            publisher.Increment(new string(ch, count));
             fakeTransport.TimesCalled.ShouldBe(1);
         }
 

--- a/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
@@ -26,61 +26,9 @@ namespace JustEat.StatsD.Buffered
             _formatter = new StatsDUtf8Formatter(configuration.Prefix);
         }
 
-        public void Increment(string bucket)
-        {
-            Increment(1, bucket);
-        }
-
-        public void Increment(long value, string bucket)
-        {
-            Increment(value, DefaultSampleRate, bucket);
-        }
-
         public void Increment(long value, double sampleRate, string bucket)
         {
-            var msg = StatsDMessage.Counter(value, bucket);
-            SendMessage(sampleRate, msg);
-        }
-
-        public void Increment(long value, double sampleRate, params string[] buckets)
-        {
-            if (buckets == null || buckets.Length == 0)
-            {
-                return;
-            }
-
-            foreach (var bucket in buckets)
-            {
-                Increment(value, sampleRate, bucket);
-            }
-        }
-
-        public void Decrement(string bucket)
-        {
-            Increment(-1, DefaultSampleRate, bucket);
-        }
-
-        public void Decrement(long value, string bucket)
-        {
-            Increment(value > 0 ? -value : value, DefaultSampleRate, bucket);
-        }
-
-        public void Decrement(long value, double sampleRate, string bucket)
-        {
-            Increment(value > 0 ? -value : value, sampleRate, bucket);
-        }
-
-        public void Decrement(long value, double sampleRate, params string[] buckets)
-        {
-            if (buckets == null || buckets.Length == 0)
-            {
-                return;
-            }
-
-            foreach (var bucket in buckets)
-            {
-                Increment(value > 0 ? -value : value, sampleRate, bucket);
-            }
+            SendMessage(sampleRate, StatsDMessage.Counter(value, bucket));
         }
 
         public void Gauge(double value, string bucket)
@@ -88,35 +36,9 @@ namespace JustEat.StatsD.Buffered
             SendMessage(DefaultSampleRate, StatsDMessage.Gauge(value, bucket));
         }
 
-        public void Gauge(long value, string bucket)
-        {
-            Gauge((double) value, bucket);
-        }
-
-        public void Timing(TimeSpan duration, string bucket)
-        {
-            Timing((long)duration.TotalMilliseconds, bucket);
-        }
-
-        public void Timing(TimeSpan duration, double sampleRate, string bucket)
-        {
-            Timing((long)duration.TotalMilliseconds, sampleRate, bucket);
-        }
-
-        public void Timing(long duration, string bucket)
-        {
-            Timing(duration, DefaultSampleRate, bucket);
-        }
-
         public void Timing(long duration, double sampleRate, string bucket)
         {
-            var msg = StatsDMessage.Timing(duration, bucket);
-            SendMessage(sampleRate, msg);
-        }
-
-        public void MarkEvent(string name)
-        {
-            Increment(name);
+            SendMessage(sampleRate, StatsDMessage.Timing(duration, bucket));
         }
 
         private void SendMessage(double sampleRate, in StatsDMessage msg)

--- a/src/JustEat.StatsD/IStatsDPublisher.cs
+++ b/src/JustEat.StatsD/IStatsDPublisher.cs
@@ -1,23 +1,32 @@
-using System;
-
 namespace JustEat.StatsD
 {
+    /// <summary>
+    /// Defines an interface for publishing counters, gauges and timers to statsD.
+    /// </summary>
     public interface IStatsDPublisher
     {
-        void Increment(string bucket);
-        void Increment(long value, string bucket);
+        /// <summary>
+        /// Publishes a counter for the specified bucket and value.
+        /// </summary>
+        /// <param name="value">The value to increment the counter by.</param>
+        /// <param name="sampleRate">The sample rate for the counter.</param>
+        /// <param name="bucket">The bucket to increment the counter for.</param>
         void Increment(long value, double sampleRate, string bucket);
-        void Increment(long value, double sampleRate, params string[] buckets);
-        void Decrement(string bucket);
-        void Decrement(long value, string bucket);
-        void Decrement(long value, double sampleRate, string bucket);
-        void Decrement(long value, double sampleRate, params string[] buckets);
+
+        /// <summary>
+        /// Publishes a gauge for the specified bucket and value.
+        /// </summary>
+        /// <param name="value">The value to publish for the gauge.</param>
+        /// <param name="sampleRate">The sample rate for the gauge.</param>
+        /// <param name="bucket">The bucket to publish the gauge for.</param>
         void Gauge(double value, string bucket);
-        void Gauge(long value, string bucket);
-        void Timing(TimeSpan duration, string bucket);
-        void Timing(TimeSpan duration, double sampleRate, string bucket);
-        void Timing(long duration, string bucket);
+
+        /// <summary>
+        /// Publishes a timer for the specified bucket and value.
+        /// </summary>
+        /// <param name="duration">The value to publish for the timer.</param>
+        /// <param name="sampleRate">The sample rate for the timer.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
         void Timing(long duration, double sampleRate, string bucket);
-        void MarkEvent(string name);
     }
 }

--- a/src/JustEat.StatsD/IStatsDPublisherExtensions.cs
+++ b/src/JustEat.StatsD/IStatsDPublisherExtensions.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace JustEat.StatsD
+{
+    /// <summary>
+    /// A class containing extension methods for the <see cref="IStatsDPublisher"/> interface. This class cannot be inherited.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class IStatsDPublisherExtensions
+    {
+        private const double DefaultSampleRate = 1.0;
+
+        /// <summary>
+        /// Publishes a counter for the specified bucket with a value of one (1).
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="bucket">The bucket to increment the counter for.</param>
+        public static void Increment(this IStatsDPublisher publisher, string bucket)
+        {
+            publisher.Increment(1, DefaultSampleRate, bucket);
+        }
+
+        /// <summary>
+        /// Publishes a counter for the specified bucket and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="value">The value to increment the counter by.</param>
+        /// <param name="bucket">The bucket to increment the counter for.</param>
+        public static void Increment(this IStatsDPublisher publisher, long value, string bucket)
+        {
+            publisher.Increment(value, DefaultSampleRate, bucket);
+        }
+
+        /// <summary>
+        /// Publishes counter(s) for the specified bucket(s) and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="value">The value to increment the counter(s) by.</param>
+        /// <param name="sampleRate">The sample rate for the counter(s).</param>
+        /// <param name="bucket">The bucket(s) to increment the counter(s) for.</param>
+        public static void Increment(this IStatsDPublisher publisher, long value, double sampleRate, IEnumerable<string> buckets)
+        {
+            if (buckets == null)
+            {
+                return;
+            }
+
+            foreach (string bucket in buckets)
+            {
+                publisher.Increment(value, sampleRate, bucket);
+            }
+        }
+
+        /// <summary>
+        /// Publishes counter(s) for the specified bucket(s) and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="value">The value to increment the counter(s) by.</param>
+        /// <param name="sampleRate">The sample rate for the counter(s).</param>
+        /// <param name="bucket">The bucket(s) to increment the counter(s) for.</param>
+        public static void Increment(this IStatsDPublisher publisher, long value, double sampleRate, params string[] buckets)
+        {
+            if (buckets == null || buckets.Length == 0)
+            {
+                return;
+            }
+
+            foreach (string bucket in buckets)
+            {
+                publisher.Increment(value, sampleRate, bucket);
+            }
+        }
+
+        /// <summary>
+        /// Publishes a counter for the specified bucket with a value of minus one (-1).
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="bucket">The bucket to decrement the counter for.</param>
+        public static void Decrement(this IStatsDPublisher publisher, string bucket)
+        {
+            publisher.Increment(-1, DefaultSampleRate, bucket);
+        }
+
+        /// <summary>
+        /// Publishes a counter decrement for the specified bucket and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="value">The value to decrement the counter by.</param>
+        /// <param name="bucket">The bucket to decrement the counter for.</param>
+        public static void Decrement(this IStatsDPublisher publisher, long value, string bucket)
+        {
+            publisher.Increment(value > 0 ? -value : value, DefaultSampleRate, bucket);
+        }
+
+        /// <summary>
+        /// Publishes a counter decrement for the specified bucket and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="value">The value to decrement the counter by.</param>
+        /// <param name="sampleRate">The sample rate for the counter.</param>
+        /// <param name="bucket">The bucket to decrement the counter for.</param>
+        public static void Decrement(this IStatsDPublisher publisher, long value, double sampleRate, string bucket)
+        {
+            publisher.Increment(value > 0 ? -value : value, sampleRate, bucket);
+        }
+
+        /// <summary>
+        /// Publishes counter decrement(s) for the specified bucket(s) and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="value">The value to decrement the counter(s) by.</param>
+        /// <param name="sampleRate">The sample rate for the counter(s).</param>
+        /// <param name="bucket">The bucket(s) to decrement the counter(s) for.</param>
+        public static void Decrement(this IStatsDPublisher publisher, long value, double sampleRate, IEnumerable<string> buckets)
+        {
+            if (buckets == null)
+            {
+                return;
+            }
+
+            long adjusted = value > 0 ? -value : value;
+
+            foreach (string bucket in buckets)
+            {
+                publisher.Increment(adjusted, sampleRate, bucket);
+            }
+        }
+
+        /// <summary>
+        /// Publishes counter decrement(s) for the specified bucket(s) and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="value">The value to decrement the counter(s) by.</param>
+        /// <param name="sampleRate">The sample rate for the counter(s).</param>
+        /// <param name="bucket">The bucket(s) to decrement the counter(s) for.</param>
+        public static void Decrement(this IStatsDPublisher publisher, long value, double sampleRate, params string[] buckets)
+        {
+            if (buckets == null || buckets.Length == 0)
+            {
+                return;
+            }
+
+            long adjusted = value > 0 ? -value : value;
+
+            foreach (string bucket in buckets)
+            {
+                publisher.Increment(adjusted, sampleRate, bucket);
+            }
+        }
+
+        /// <summary>
+        /// Publishes a timer for the specified bucket and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="duration">The value to publish for the timer.</param>
+        /// <param name="sampleRate">The sample rate for the timer.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        public static void Timing(this IStatsDPublisher publisher, TimeSpan duration, string bucket)
+        {
+            publisher.Timing((long)duration.TotalMilliseconds, DefaultSampleRate, bucket);
+        }
+
+        /// <summary>
+        /// Publishes a timer for the specified bucket and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="duration">The value to publish for the timer.</param>
+        /// <param name="sampleRate">The sample rate for the timer.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        public static void Timing(this IStatsDPublisher publisher, TimeSpan duration, double sampleRate, string bucket)
+        {
+            publisher.Timing((long)duration.TotalMilliseconds, sampleRate, bucket);
+        }
+
+        /// <summary>
+        /// Publishes a timer for the specified bucket and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="duration">The value to publish for the timer.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        public static void Timing(this IStatsDPublisher publisher, long duration, string bucket)
+        {
+            publisher.Timing(duration, DefaultSampleRate, bucket);
+        }
+    }
+}

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -82,87 +82,15 @@ namespace JustEat.StatsD
         }
 
         /// <inheritdoc />
-        public void MarkEvent(string name)
-        {
-            _inner.MarkEvent(name);
-        }
-
-        /// <inheritdoc />
-        public void Increment(string bucket)
-        {
-            _inner.Increment(bucket);
-        }
-
-        /// <inheritdoc />
-        public void Increment(long value, string bucket)
-        {
-            _inner.Increment(value, bucket);
-        }
-
-        /// <inheritdoc />
         public void Increment(long value, double sampleRate, string bucket)
         {
             _inner.Increment(value, sampleRate, bucket);
         }
 
         /// <inheritdoc />
-        public void Increment(long value, double sampleRate, params string[] buckets)
-        {
-            _inner.Increment(value, sampleRate, buckets);
-        }
-
-        /// <inheritdoc />
-        public void Decrement(string bucket)
-        {
-            _inner.Decrement(bucket);
-        }
-
-        /// <inheritdoc />
-        public void Decrement(long value, string bucket)
-        {
-            _inner.Decrement(value, bucket);
-        }
-
-        /// <inheritdoc />
-        public void Decrement(long value, double sampleRate, string bucket)
-        {
-            _inner.Decrement(value, sampleRate, bucket);
-        }
-
-        /// <inheritdoc />
-        public void Decrement(long value, double sampleRate, params string[] buckets)
-        {
-            _inner.Decrement(value, sampleRate, buckets);
-        }
-
-        /// <inheritdoc />
         public void Gauge(double value, string bucket)
         {
             _inner.Gauge(value, bucket);
-        }
-
-        /// <inheritdoc />
-        public void Gauge(long value, string bucket)
-        {
-            _inner.Gauge(value, bucket);
-        }
-
-        /// <inheritdoc />
-        public void Timing(TimeSpan duration, string bucket)
-        {
-            _inner.Timing(duration, bucket);
-        }
-
-        /// <inheritdoc />
-        public void Timing(TimeSpan duration, double sampleRate, string bucket)
-        {
-            _inner.Timing(duration, sampleRate, bucket);
-        }
-
-        /// <inheritdoc />
-        public void Timing(long duration, string bucket)
-        {
-            _inner.Timing(duration, bucket);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
  * Simplify the `IStatsDPublisher` interface by removing all the overloads and moving them to convenience extension methods.
  * Remove the `MarkEvent()` method as it's just an alias to `Increment()`.
  * Add XML documentation to `IStatsDPublisher`.
