### PR TITLE
XML documentation updates

### DIFF
--- a/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
+++ b/src/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
@@ -131,7 +131,7 @@ namespace JustEat.StatsD.Extensions
         public static void CanRecordStatInFunction()
         {
             var publisher = new FakeStatsPublisher();
-            var answer = publisher.Time("statOverFunc", t => DelayedAnswer());
+            var answer = publisher.Time("statOverFunc", () => DelayedAnswer());
 
             answer.ShouldBe(42);
             PublisherAssertions.SingleStatNameIs(publisher, "statOverFunc");
@@ -142,7 +142,7 @@ namespace JustEat.StatsD.Extensions
         public static async Task CanRecordStatInAsyncAction()
         {
             var publisher = new FakeStatsPublisher();
-            await publisher.Time("statOverAsyncAction", async t => await DelayAsync());
+            await publisher.Time("statOverAsyncAction", async () => await DelayAsync());
 
             PublisherAssertions.SingleStatNameIs(publisher, "statOverAsyncAction");
         }
@@ -151,7 +151,7 @@ namespace JustEat.StatsD.Extensions
         public static async Task CorrectDurationForStatInAsyncAction()
         {
             var publisher = new FakeStatsPublisher();
-            await publisher.Time("stat", async t => await DelayAsync());
+            await publisher.Time("stat", async () => await DelayAsync());
 
             PublisherAssertions.LastDurationIs(publisher, TimingConstants.DelayMilliseconds);
         }
@@ -160,7 +160,7 @@ namespace JustEat.StatsD.Extensions
         public static async Task CanRecordStatInAsyncFunction()
         {
             var publisher = new FakeStatsPublisher();
-            var answer = await publisher.Time("statOverAsyncFunc", async t => await DelayedAnswerAsync());
+            var answer = await publisher.Time("statOverAsyncFunc", async () => await DelayedAnswerAsync());
 
             answer.ShouldBe(42);
             PublisherAssertions.SingleStatNameIs(publisher, "statOverAsyncFunc");
@@ -170,7 +170,7 @@ namespace JustEat.StatsD.Extensions
         public static async Task CorrectDurationForStatInAsyncFunction()
         {
             var publisher = new FakeStatsPublisher();
-            await publisher.Time("stat", async t => await DelayedAnswerAsync());
+            await publisher.Time("stat", async () => await DelayedAnswerAsync());
 
             PublisherAssertions.LastDurationIs(publisher, TimingConstants.DelayMilliseconds);
         }

--- a/src/JustEat.StatsD/EndpointLookups/CachedEndpointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/CachedEndpointSource.cs
@@ -4,23 +4,32 @@ using System.Net;
 namespace JustEat.StatsD.EndpointLookups
 {
     /// <summary>
-    /// cache the IPEndPoint and only go to the source when it expires
+    /// A class representing an implementation of <see cref="IEndPointSource"/> that caches
+    /// the <see cref="EndPoint"/> for a fixed period of time before refreshing its value.
     /// </summary>
     public class CachedEndpointSource : IEndPointSource
     {
+        private readonly IEndPointSource _inner;
+        private readonly TimeSpan _cacheDuration;
         private EndPoint _cachedValue;
         private DateTime _expiry;
-        private readonly TimeSpan _cacheDuration;
 
-        private readonly IEndPointSource _inner;
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CachedEndpointSource"/> class.
+        /// </summary>
+        /// <param name="inner">The inner <see cref="IEndPointSource"/> to use.</param>
+        /// <param name="cacheDuration">The duration values should be cached for.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="inner"/> is <see langword="null"/>.
+        /// </exception>
         public CachedEndpointSource(IEndPointSource inner, TimeSpan cacheDuration)
         {
-            _inner = inner;
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
             _cachedValue = null;
             _cacheDuration = cacheDuration;
         }
 
+        /// <inheritdoc />
         public EndPoint GetEndpoint()
         {
             if (NeedsRead())

--- a/src/JustEat.StatsD/EndpointLookups/DnsLookupIpEndpointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/DnsLookupIpEndpointSource.cs
@@ -6,22 +6,33 @@ using System.Net.Sockets;
 namespace JustEat.StatsD.EndpointLookups
 {
     /// <summary>
-    /// lookup IPAddress using DNS to find the host's IP
+    /// A class representing an implementation of <see cref="IEndPointSource"/> that looks up
+    /// the <see cref="EndPoint"/> for DNS hostname to resolve its IP address.
     /// </summary>
     public class DnsLookupIpEndpointSource : IEndPointSource
     {
         private readonly string _hostName;
         private readonly int _port;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DnsLookupIpEndpointSource"/> class.
+        /// </summary>
+        /// <param name="hostName">The host name to look up the IP address for.</param>
+        /// <param name="port">The port number to use for the end point.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="hostName"/> is <see langword="null"/>.
+        /// </exception>
         public DnsLookupIpEndpointSource(string hostName, int port)
         {
-            _hostName = hostName;
+            _hostName = hostName ?? throw new ArgumentNullException(nameof(hostName));
             _port = port;
         }
 
+        /// <inheritdoc />
         public EndPoint GetEndpoint()
         {
-            return new IPEndPoint(GetIpAddressOfHost(_hostName), _port);
+            var address = GetIpAddressOfHost(_hostName);
+            return new IPEndPoint(address, _port);
         }
 
         private static IPAddress GetIpAddressOfHost(string hostName)
@@ -30,7 +41,7 @@ namespace JustEat.StatsD.EndpointLookups
 
             if (endpoints == null || endpoints.Length == 0)
             {
-                throw new Exception($"DNS did not find any addresses for statsd host '${hostName}'");
+                throw new Exception($"Failed to resolve any IP addresses for statsd host '${hostName}' using DNS.");
             }
 
             IPAddress result = null;

--- a/src/JustEat.StatsD/EndpointLookups/IEndPointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/IEndPointSource.cs
@@ -2,8 +2,17 @@ using System.Net;
 
 namespace JustEat.StatsD.EndpointLookups
 {
+    /// <summary>
+    /// Defines a method for retrieving the endpoint for a statsd server.
+    /// </summary>
     public interface IEndPointSource
     {
+        /// <summary>
+        /// Returns an <see cref="EndPoint"/> to use for a statsd server.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="EndPoint"/> to use to publish metrics.
+        /// </returns>
         EndPoint GetEndpoint();
     }
 }

--- a/src/JustEat.StatsD/EndpointLookups/SimpleEndpointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/SimpleEndpointSource.cs
@@ -1,19 +1,29 @@
+using System;
 using System.Net;
 
 namespace JustEat.StatsD.EndpointLookups
 {
     /// <summary>
-    /// Simple adapter
+    /// A class representing an implementation of <see cref="IEndPointSource"/> that
+    /// returns a constant <see cref="EndPoint"/> value. This class cannot be inherited.
     /// </summary>
-    public class SimpleEndpointSource : IEndPointSource
+    public sealed class SimpleEndpointSource : IEndPointSource
     {
         private readonly EndPoint _value;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleEndpointSource"/> class.
+        /// </summary>
+        /// <param name="value">The <see cref="EndPoint"/> to use.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="value"/> is <see langword="null"/>.
+        /// </exception>
         public SimpleEndpointSource(EndPoint value)
         {
-            _value = value;
+            _value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
+        /// <inheritdoc />
         public EndPoint GetEndpoint() => _value;
     }
 }

--- a/src/JustEat.StatsD/IDisposableTimer.cs
+++ b/src/JustEat.StatsD/IDisposableTimer.cs
@@ -1,9 +1,15 @@
-﻿using System;
+using System;
 
 namespace JustEat.StatsD
 {
+    /// <summary>
+    /// Defines a timer which is disposable.
+    /// </summary>
     public interface IDisposableTimer : IDisposable
     {
+        /// <summary>
+        /// Gets the name of the statsd bucket associated with the timer.
+        /// </summary>
         string StatName { get; set; }
     }
 }

--- a/src/JustEat.StatsD/IDisposableTimer.cs
+++ b/src/JustEat.StatsD/IDisposableTimer.cs
@@ -8,7 +8,7 @@ namespace JustEat.StatsD
     public interface IDisposableTimer : IDisposable
     {
         /// <summary>
-        /// Gets the name of the statsd bucket associated with the timer.
+        /// Gets or sets the name of the statsd bucket associated with the timer.
         /// </summary>
         string StatName { get; set; }
     }

--- a/src/JustEat.StatsD/IStatsDPublisher.cs
+++ b/src/JustEat.StatsD/IStatsDPublisher.cs
@@ -17,7 +17,6 @@ namespace JustEat.StatsD
         /// Publishes a gauge for the specified bucket and value.
         /// </summary>
         /// <param name="value">The value to publish for the gauge.</param>
-        /// <param name="sampleRate">The sample rate for the gauge.</param>
         /// <param name="bucket">The bucket to publish the gauge for.</param>
         void Gauge(double value, string bucket);
 

--- a/src/JustEat.StatsD/IStatsDPublisherExtensions.cs
+++ b/src/JustEat.StatsD/IStatsDPublisherExtensions.cs
@@ -15,7 +15,7 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes a counter for the specified bucket with a value of one (1).
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to increment the counter for.</param>
         public static void Increment(this IStatsDPublisher publisher, string bucket)
         {
@@ -25,7 +25,7 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes a counter for the specified bucket and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to increment the counter by.</param>
         /// <param name="bucket">The bucket to increment the counter for.</param>
         public static void Increment(this IStatsDPublisher publisher, long value, string bucket)
@@ -36,10 +36,10 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes counter(s) for the specified bucket(s) and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to increment the counter(s) by.</param>
         /// <param name="sampleRate">The sample rate for the counter(s).</param>
-        /// <param name="bucket">The bucket(s) to increment the counter(s) for.</param>
+        /// <param name="buckets">The bucket(s) to increment the counter(s) for.</param>
         public static void Increment(this IStatsDPublisher publisher, long value, double sampleRate, IEnumerable<string> buckets)
         {
             if (buckets == null)
@@ -56,10 +56,10 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes counter(s) for the specified bucket(s) and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to increment the counter(s) by.</param>
         /// <param name="sampleRate">The sample rate for the counter(s).</param>
-        /// <param name="bucket">The bucket(s) to increment the counter(s) for.</param>
+        /// <param name="buckets">The bucket(s) to increment the counter(s) for.</param>
         public static void Increment(this IStatsDPublisher publisher, long value, double sampleRate, params string[] buckets)
         {
             if (buckets == null || buckets.Length == 0)
@@ -76,7 +76,7 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes a counter for the specified bucket with a value of minus one (-1).
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to decrement the counter for.</param>
         public static void Decrement(this IStatsDPublisher publisher, string bucket)
         {
@@ -86,7 +86,7 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes a counter decrement for the specified bucket and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to decrement the counter by.</param>
         /// <param name="bucket">The bucket to decrement the counter for.</param>
         public static void Decrement(this IStatsDPublisher publisher, long value, string bucket)
@@ -97,7 +97,7 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes a counter decrement for the specified bucket and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to decrement the counter by.</param>
         /// <param name="sampleRate">The sample rate for the counter.</param>
         /// <param name="bucket">The bucket to decrement the counter for.</param>
@@ -109,10 +109,10 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes counter decrement(s) for the specified bucket(s) and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to decrement the counter(s) by.</param>
         /// <param name="sampleRate">The sample rate for the counter(s).</param>
-        /// <param name="bucket">The bucket(s) to decrement the counter(s) for.</param>
+        /// <param name="buckets">The bucket(s) to decrement the counter(s) for.</param>
         public static void Decrement(this IStatsDPublisher publisher, long value, double sampleRate, IEnumerable<string> buckets)
         {
             if (buckets == null)
@@ -131,10 +131,10 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes counter decrement(s) for the specified bucket(s) and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to decrement the counter(s) by.</param>
         /// <param name="sampleRate">The sample rate for the counter(s).</param>
-        /// <param name="bucket">The bucket(s) to decrement the counter(s) for.</param>
+        /// <param name="buckets">The bucket(s) to decrement the counter(s) for.</param>
         public static void Decrement(this IStatsDPublisher publisher, long value, double sampleRate, params string[] buckets)
         {
             if (buckets == null || buckets.Length == 0)
@@ -153,9 +153,8 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes a timer for the specified bucket and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="duration">The value to publish for the timer.</param>
-        /// <param name="sampleRate">The sample rate for the timer.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         public static void Timing(this IStatsDPublisher publisher, TimeSpan duration, string bucket)
         {
@@ -165,7 +164,7 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes a timer for the specified bucket and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="duration">The value to publish for the timer.</param>
         /// <param name="sampleRate">The sample rate for the timer.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
@@ -177,7 +176,7 @@ namespace JustEat.StatsD
         /// <summary>
         /// Publishes a timer for the specified bucket and value.
         /// </summary>
-        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publisher with.</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="duration">The value to publish for the timer.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         public static void Timing(this IStatsDPublisher publisher, long duration, string bucket)

--- a/src/JustEat.StatsD/IStatsDTransport.cs
+++ b/src/JustEat.StatsD/IStatsDTransport.cs
@@ -2,8 +2,15 @@ using System;
 
 namespace JustEat.StatsD
 {
+    /// <summary>
+    /// Defines a transport for sending metrics to a statsd server.
+    /// </summary>
     public interface IStatsDTransport
     {
+        /// <summary>
+        /// Sends the metric represented by the specified array segment to the server.
+        /// </summary>
+        /// <param name="metric">An <see cref="ArraySegment{T}"/> containing the bytes of the metric to send.</param>
         void Send(in ArraySegment<byte> metric);
     }
 }

--- a/src/JustEat.StatsD/IStatsDTransportExtensions.cs
+++ b/src/JustEat.StatsD/IStatsDTransportExtensions.cs
@@ -11,6 +11,14 @@ namespace JustEat.StatsD
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class IStatsDTransportExtensions
     {
+        /// <summary>
+        /// Sends the specified metrics to the statsD server.
+        /// </summary>
+        /// <param name="transport">The <see cref="IStatsDTransport"/> to use.</param>
+        /// <param name="metrics">The metric(s) to send.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="transport"/> or <paramref name="metrics"/> is <see langword="null"/>.
+        /// </exception>
         public static void Send(this IStatsDTransport transport, IEnumerable<string> metrics)
         {
             if (transport == null)
@@ -29,6 +37,14 @@ namespace JustEat.StatsD
             }
         }
 
+        /// <summary>
+        /// Sends the specified metric to the statsD server.
+        /// </summary>
+        /// <param name="transport">The <see cref="IStatsDTransport"/> to use.</param>
+        /// <param name="metric">The metric to send.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="transport"/> or <paramref name="metric"/> is <see langword="null"/>.
+        /// </exception>
         public static void Send(this IStatsDTransport transport, string metric)
         {
             if (transport == null)

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET library for publishing metrics to statsd.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OutputType>Library</OutputType>
     <PackageId>JustEat.StatsD</PackageId>
     <RootNamespace>JustEat.StatsD</RootNamespace>

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -2,49 +2,66 @@ using System;
 
 namespace JustEat.StatsD
 {
+    /// <summary>
+    /// A class representing the configuration options for statsD usage.
+    /// </summary>
     public class StatsDConfiguration
     {
+        /// <summary>
+        /// The default statsD port, 8125.
+        /// </summary>
         public const int DefaultPort = 8125;
-        public static readonly TimeSpan DefaultDnsLookupInterval = TimeSpan.FromMinutes(5);
 
         /// <summary>
-        /// The host name or IP address of the statsD server. 
-        /// This field must be set. 
+        /// Gets the default DNS lookup interval, which is 5 minutes.
         /// </summary>
+        public static TimeSpan DefaultDnsLookupInterval => TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Gets or sets the host name or IP address of the statsD server. 
+        /// </summary>
+        /// <remarks>
+        /// A value must be provided for this property.
+        /// </remarks>
         public string Host { get; set; }
 
         /// <summary>
-        /// The port on the statsD server to use.
-        /// Default is the standard port (8125).
+        /// Gets or sets the port on the statsD server to use.
         /// </summary>
         public int Port { get; set; } = DefaultPort;
 
         /// <summary>
-        /// Length of time to cache the host name to IP address lookup.
-        /// Only used when "Host" contains a host name.
-        /// Default is 5 minutes.
+        /// Gets or sets the length of time to cache the hostname for IP address lookup using DNS.
         /// </summary>
+        /// <remarks>
+        /// This value is only used when <see cref="Host"/> is a hostname, rather than an IP address.
+        /// <para />
+        /// The default value of this property is the value of <see cref="DefaultDnsLookupInterval"/>.
+        /// </remarks>
         public TimeSpan? DnsLookupInterval { get; set; } = DefaultDnsLookupInterval;
 
         /// <summary>
-        /// Configure to use either UDP or IP sockets to transport stats.
-        /// Default is UDP.
+        /// Gets or sets the socket protocol to use, such as using either UDP or IP
+        /// sockets to transport stats. The default value is <see cref="SocketProtocol.Udp"/>.
         /// </summary>
         public SocketProtocol SocketProtocol { get; set; } = SocketProtocol.Udp;
 
         /// <summary>
-        /// Prepend a prefix to all stats.
-        /// Default is empty.
+        /// Gets or sets an optional prefix to use for all stats.
         /// </summary>
         public string Prefix { get; set; } = string.Empty;
 
         /// <summary>
-        /// Function to receive notification of any exceptions
-        /// This function should return:
-        /// True if the exception was handled and no further action is needed
-        /// False if the exception should be thrown
-        /// The default behaviour is to ignore the error
+        /// Gets or sets an optional delegate to invoke when an error occurs
+        /// when sending a metric to the statsD server.
         /// </summary>
+        /// <remarks>
+        /// This delegate should return <see langword="true"/> if the exception
+        /// was handled and no further action is needed, otherwise <see langword="false"/>
+        /// if the exception should be thrown.
+        /// <para/>
+        /// The default behaviour is to ignore the exception.
+        /// </remarks>
         public Func<Exception, bool> OnError { get; set; }
     }
 }

--- a/src/JustEat.StatsD/StatsDMessageFormatter.cs
+++ b/src/JustEat.StatsD/StatsDMessageFormatter.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace JustEat.StatsD
 {
-    public class StatsDMessageFormatter
+    internal sealed class StatsDMessageFormatter
     {
         private const double DefaultSampleRate = 1.0;
 

--- a/src/JustEat.StatsD/TimerExtensions.cs
+++ b/src/JustEat.StatsD/TimerExtensions.cs
@@ -1,27 +1,50 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace JustEat.StatsD
 {
+    /// <summary>
+    /// A class containing timing extension methods for the <see cref="IStatsDPublisher"/> interface. This class cannot be inherited.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class TimerExtensions
     {
         /// <summary>
-        /// Start a timer for use in a "using" statement
+        /// Starts a new timer for the specified bucket which is published when the return value is disposed of.
         /// </summary>
-        /// <param name="publisher">the stats publisher</param>
-        /// <param name="bucket">the stat name</param>
-        /// <returns>the disposable timer</returns>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <returns>
+        /// An <see cref="IDisposableTimer"/> that publishes the metric when the instance is disposed of.
+        /// </returns>
         public static IDisposableTimer StartTimer(this IStatsDPublisher publisher, string bucket)
         {
             return new DisposableTimer(publisher, bucket);
         }
 
         /// <summary>
-        /// functional style for timing an delegate with no return value, is not async
+        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// and is stopped and published when the delegate invocation completes.
         /// </summary>
-        /// <param name="publisher">the stats publisher</param>
-        /// <param name="bucket">the stat name</param>
-        /// <param name="action">the delegate to time</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="action">A delegate to a method whose invocation should be timed.</param>
+        public static void Time(this IStatsDPublisher publisher, string bucket, Action action)
+        {
+            using (StartTimer(publisher, bucket))
+            {
+                action();
+            }
+        }
+
+        /// <summary>
+        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// and is stopped and published when the delegate invocation completes.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="action">A delegate to a method whose invocation should be timed.</param>
         public static void Time(this IStatsDPublisher publisher, string bucket, Action<IDisposableTimer> action)
         {
             using (var timer = StartTimer(publisher, bucket))
@@ -31,11 +54,34 @@ namespace JustEat.StatsD
         }
 
         /// <summary>
-        /// functional style for timing an delegate with no return value, is async
+        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// and awaited, and is stopped and published when the asynchronous delegate invocation completes.
         /// </summary>
-        /// <param name="publisher">the stats publisher</param>
-        /// <param name="bucket">the stat name</param>
-        /// <param name="action">the delegate to time</param>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="action">A delegate to a method whose invocation should be timed.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation to time.
+        /// </returns>
+        public static async Task Time(this IStatsDPublisher publisher, string bucket, Func<Task> action)
+        {
+            using (StartTimer(publisher, bucket))
+            {
+                await action().ConfigureAwait(false);
+            }
+        }
+
+
+        /// <summary>
+        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// and awaited, and is stopped and published when the asynchronous delegate invocation completes.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="action">A delegate to a method whose invocation should be timed.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation to time.
+        /// </returns>
         public static async Task Time(this IStatsDPublisher publisher, string bucket, Func<IDisposableTimer, Task> action)
         {
             using (var timer = StartTimer(publisher, bucket))
@@ -45,11 +91,35 @@ namespace JustEat.StatsD
         }
 
         /// <summary>
-        /// functional style for timing a function with a return value, is not async
+        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// and is stopped and published when the delegate invocation completes.
         /// </summary>
-        /// <param name="publisher">the stats publisher</param>
-        /// <param name="bucket">the stat name</param>
-        /// <param name="func">the function to time</param>
+        /// <typeparam name="T">The type of the result of the delegate to invoke.</typeparam>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="func">A delegate to a method whose invocation should be timed and result returned.</param>
+        /// <returns>
+        /// The value from invoking <paramref name="func"/>.
+        /// </returns>
+        public static T Time<T>(this IStatsDPublisher publisher, string bucket, Func<T> func)
+        {
+            using (StartTimer(publisher, bucket))
+            {
+                return func();
+            }
+        }
+
+        /// <summary>
+        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// and is stopped and published when the delegate invocation completes.
+        /// </summary>
+        /// <typeparam name="T">The type of the result of the delegate to invoke.</typeparam>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="func">A delegate to a method whose invocation should be timed and result returned.</param>
+        /// <returns>
+        /// The value from invoking <paramref name="func"/>.
+        /// </returns>
         public static T Time<T>(this IStatsDPublisher publisher, string bucket, Func<IDisposableTimer, T> func)
         {
             using (var timer = StartTimer(publisher, bucket))
@@ -58,13 +128,36 @@ namespace JustEat.StatsD
             }
         }
 
+        /// <summary>
+        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// and awaited, and is stopped and published when the asynchronous delegate invocation completes.
+        /// </summary>
+        /// <typeparam name="T">The type of the result of the delegate to invoke.</typeparam>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="func">A delegate to a method whose invocation should be timed and result returned.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation to time.
+        /// </returns>
+        public static async Task<T> Time<T>(this IStatsDPublisher publisher, string bucket, Func<Task<T>> func)
+        {
+            using (StartTimer(publisher, bucket))
+            {
+                return await func().ConfigureAwait(false);
+            }
+        }
 
         /// <summary>
-        /// functional style for timing a function with a return value, is async
+        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// and awaited, and is stopped and published when the asynchronous delegate invocation completes.
         /// </summary>
-        /// <param name="publisher">the stats publisher</param>
-        /// <param name="bucket">the stat name</param>
-        /// <param name="func">the function to time</param>
+        /// <typeparam name="T">The type of the result of the delegate to invoke.</typeparam>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="func">A delegate to a method whose invocation should be timed and result returned.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation to time.
+        /// </returns>
         public static async Task<T> Time<T>(this IStatsDPublisher publisher, string bucket, Func<IDisposableTimer, Task<T>> func)
         {
             using (var timer = StartTimer(publisher, bucket))


### PR DESCRIPTION
  * Add missing XML documentation.
  * Add some missing parameter validation.
  * Updates to grammar in some error messages.
  * Fix some incorrect XML documentation.
  * Make `StatsDMessageFormatter` internal (so we don't have to document it).
  * Add some extra overloads to `TimerExtensions` to remove the need to have a parameter for `IDisposableTimer` if you aren't going to use it, which can help save on allocations for delegates if you don't otherwise need a lambda.

Relates to #130.
