### PR TITLE
Add NuGet config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ project.lock.json
 TestResult.xml
 !3rdparty/*/bin
 lint.db
-BenchmarkDotNet.Artifacts
+BenchmarkDotNet.Artifacts*

--- a/JustEat.StatsD.sln
+++ b/JustEat.StatsD.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{06BE4D
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
 		LICENSE = LICENSE
+		NuGet.config = NuGet.config
 		README.md = README.md
 		release.ps1 = release.ps1
 		version.props = version.props

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
I've been doing some benchmarks for all the releases of JustEat.StatsD since we added .NET Core support to get some comparisons, and that required using a custom NuGet.config to restore packages from the AppVeyor CI feed.

This PR adds the vanilla NuGet.config file to the repo so that's easier to do in future without having to create one from scratch.

I've also extended the BenchmarkDotNet artifact wildcard in `.gitignore` to ignore the slightly different naming convention I'm using locally to generate a folder per StatsD-version/TFM combination.