### PR TITLE
Fix NullReferenceException

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2017
-version: 3.2.2.{build}
+version: 3.2.3.{build}
 configuration: Release
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/src/JustEat.StatsD.Tests/PooledUdpTransportTests.cs
+++ b/src/JustEat.StatsD.Tests/PooledUdpTransportTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Xunit;
+
+namespace JustEat.StatsD
+{
+    public static class PooledUdpTransportTests
+    {
+        [Fact]
+        public static void Finalizer_Does_Not_Throw_If_Socket_Connect_Fails()
+        {
+            // Arrange
+            var configuration = new StatsDConfiguration()
+            {
+                Host = "0",
+            };
+
+            var endPointSource = EndpointLookups.EndpointParser.MakeEndPointSource(
+                configuration.Host,
+                configuration.Port,
+                configuration.DnsLookupInterval);
+
+            using (var transport = new PooledUdpTransport(endPointSource))
+            {
+                try
+                {
+                    // Act - Constructor of ConnectedSocketPool will throw
+                    transport.Send("foo");
+                }
+                catch (Exception)
+                {
+                    // Ignore
+                }
+            }
+
+            // Assert - Force the finalizers to run, ~ConnectedSocketPool would
+            // throw a NullReferenceException and terminate the process.
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+}

--- a/src/JustEat.StatsD/ConnectedSocketPool.cs
+++ b/src/JustEat.StatsD/ConnectedSocketPool.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Runtime.CompilerServices;
 
 namespace JustEat.StatsD
 {
@@ -65,7 +64,7 @@ namespace JustEat.StatsD
             {
                 try
                 {
-                    while (_pool.Count > 0)
+                    while (_pool?.Count > 0)
                     {
                         var socket = _pool.Pop();
                         socket?.Dispose();

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <VersionPrefix>3.2.2</VersionPrefix>
+    <VersionPrefix>3.2.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
 
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>


### PR DESCRIPTION
Whether it's worth publishing a `3.2.3` with _just_ this fix in it or not is debatable, but the `3.x.x` code base has a bug in it where a `NullReferenceException` is thrown on the finalizer thread and terminates the process if an exception occurs while creating a `ConnectedSocketPool` because `_pool` never ends up with a value.

```
The active test run was aborted. Reason: Unhandled Exception: System.NullReferenceException: Object reference not set to
 an instance of an object.
   at JustEat.StatsD.ConnectedSocketPool.Dispose(Boolean disposing) in C:\Coding\JustEat.StatsD\src\JustEat.StatsD\Conne
ctedSocketPool.cs:line 67
   at JustEat.StatsD.ConnectedSocketPool.Finalize() in C:\Coding\JustEat.StatsD\src\JustEat.StatsD\ConnectedSocketPool.c
s:line 51
```