### PR TITLE
Rename EndpointParser

### DIFF
--- a/src/JustEat.StatsD/EndpointLookups/EndpointParser.cs
+++ b/src/JustEat.StatsD/EndpointLookups/EndpointParser.cs
@@ -3,12 +3,10 @@ using System.Net;
 
 namespace JustEat.StatsD.EndpointLookups
 {
-    //// TODO Is this more of a EndPointFactory?
-
     /// <summary>
-    /// A class containing methods to instances of <see cref="IEndPointSource"/>. This class cannot be inherited.
+    /// A class containing methods to create instances of <see cref="IEndPointSource"/>. This class cannot be inherited.
     /// </summary>
-    public static class EndpointParser
+    public static class EndPointFactory
     {
         /// <summary>
         /// Creates an <see cref="IEndPointSource"/> from the specified <see cref="EndPoint"/>.

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -70,7 +70,7 @@ namespace JustEat.StatsD
                 throw new ArgumentException("No hostname or IP address is set.", nameof(configuration));
             }
 
-            var endpointSource = EndpointParser.MakeEndPointSource(
+            var endpointSource = EndPointFactory.MakeEndPointSource(
                 configuration.Host, configuration.Port, configuration.DnsLookupInterval);
 
             var transport = new SocketTransport(endpointSource, configuration.SocketProtocol);

--- a/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
+++ b/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
@@ -111,7 +111,7 @@ namespace JustEat.StatsD
         {
             var config = provider.GetRequiredService<StatsDConfiguration>();
 
-            return EndpointParser.MakeEndPointSource(
+            return EndPointFactory.MakeEndPointSource(
                 config.Host,
                 config.Port,
                 config.DnsLookupInterval);

--- a/tests/Benchmark/StatSendingBenchmark.cs
+++ b/tests/Benchmark/StatSendingBenchmark.cs
@@ -25,7 +25,7 @@ namespace Benchmark
                 Prefix = "testmetric"
             };
 
-            var endpointSource = EndpointParser.MakeEndPointSource(
+            var endpointSource = EndPointFactory.MakeEndPointSource(
                 config.Host, config.Port, config.DnsLookupInterval);
 
             var ipTransport = new SocketTransport(endpointSource, SocketProtocol.IP);

--- a/tests/Benchmark/UdpStatSendingBenchmark.cs
+++ b/tests/Benchmark/UdpStatSendingBenchmark.cs
@@ -26,7 +26,7 @@ namespace Benchmark
                 Prefix = "testmetric"
             };
 
-            var endpointSource = EndpointParser.MakeEndPointSource(
+            var endpointSource = EndPointFactory.MakeEndPointSource(
                 config.Host,
                 config.Port,
                 config.DnsLookupInterval);

--- a/tests/Benchmark/UdpTransportBenchmark.cs
+++ b/tests/Benchmark/UdpTransportBenchmark.cs
@@ -41,12 +41,12 @@ namespace Benchmark
                 Host = "127.0.0.1",
             };
 
-            var endpointSource1 = EndpointParser.MakeEndPointSource(
+            var endpointSource1 = EndPointFactory.MakeEndPointSource(
                 config.Host,
                 config.Port,
                 config.DnsLookupInterval);
 
-            var endpointSource2 = EndpointParser.MakeEndPointSource(
+            var endpointSource2 = EndPointFactory.MakeEndPointSource(
                 config.Host,
                 config.Port + 1,
                 config.DnsLookupInterval);

--- a/tests/JustEat.StatsD.Tests/EndpointLookups/EndPointFactoryTests.cs
+++ b/tests/JustEat.StatsD.Tests/EndpointLookups/EndPointFactoryTests.cs
@@ -1,16 +1,16 @@
-﻿using System;
+using System;
 using System.Net;
 using Shouldly;
 using Xunit;
 
 namespace JustEat.StatsD.EndpointLookups
 {
-    public static class EndpointParserTests
+    public static class EndPointFactoryTests
     {
         [Fact]
         public static void CanParseIpValue()
         {
-            var parsed = EndpointParser.MakeEndPointSource("11.12.13.14", 8125, null);
+            var parsed = EndPointFactory.MakeEndPointSource("11.12.13.14", 8125, null);
 
             parsed.ShouldNotBeNull();
 
@@ -21,14 +21,14 @@ namespace JustEat.StatsD.EndpointLookups
         [Fact]
         public static void CanParseHostValue()
         {
-            var parsed = EndpointParser.MakeEndPointSource("somehost.somewhere.com", 8125, null);
+            var parsed = EndPointFactory.MakeEndPointSource("somehost.somewhere.com", 8125, null);
             parsed.ShouldNotBeNull();
         }
 
         [Fact]
         public static void CanParseLocalhostValue()
         {
-            var parsed = EndpointParser.MakeEndPointSource("localhost", 8125, null);
+            var parsed = EndPointFactory.MakeEndPointSource("localhost", 8125, null);
             parsed.ShouldNotBeNull();
             parsed.GetEndpoint().ShouldNotBeNull();
         }
@@ -36,7 +36,7 @@ namespace JustEat.StatsD.EndpointLookups
         [Fact]
         public static void CanParseCachedLocalhostValue()
         {
-            var parsed = EndpointParser.MakeEndPointSource("localhost", 8125, TimeSpan.FromMinutes(5));
+            var parsed = EndPointFactory.MakeEndPointSource("localhost", 8125, TimeSpan.FromMinutes(5));
             parsed.ShouldNotBeNull();
             parsed.GetEndpoint().ShouldNotBeNull();
         }
@@ -44,7 +44,7 @@ namespace JustEat.StatsD.EndpointLookups
         [Fact]
         public static void CanParseHostValueWithCache()
         {
-            var parsed = EndpointParser.MakeEndPointSource("somehost.somewhere.com", 8125, TimeSpan.FromMinutes(5));
+            var parsed = EndPointFactory.MakeEndPointSource("somehost.somewhere.com", 8125, TimeSpan.FromMinutes(5));
             parsed.ShouldNotBeNull();
         }
     }

--- a/tests/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
+++ b/tests/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
@@ -20,7 +20,7 @@ namespace JustEat.StatsD
         public void AMetricCanBeSentWithoutAnExceptionBeingThrown()
         {
             // Arrange
-            var endPointSource = EndpointParser.MakeEndPointSource(
+            var endPointSource = EndPointFactory.MakeEndPointSource(
                 UdpListeners.EndpointA,
                 null);
 
@@ -35,7 +35,7 @@ namespace JustEat.StatsD
         public void MultipleMetricsCanBeSentWithoutAnExceptionBeingThrownSerial()
         {
             // Arrange
-            var endPointSource = EndpointParser.MakeEndPointSource(
+            var endPointSource = EndPointFactory.MakeEndPointSource(
                 UdpListeners.EndpointA,
                 null);
 
@@ -53,7 +53,7 @@ namespace JustEat.StatsD
         public void MultipleMetricsCanBeSentWithoutAnExceptionBeingThrownParallel()
         {
             // Arrange
-            var endPointSource = EndpointParser.MakeEndPointSource(
+            var endPointSource = EndPointFactory.MakeEndPointSource(
                 UdpListeners.EndpointA,
                 null);
 
@@ -71,11 +71,11 @@ namespace JustEat.StatsD
         public static void EndpointSwitchShouldNotCauseExceptionsSequential()
         {
             // Arrange
-            var endPointSource1 = EndpointParser.MakeEndPointSource(
+            var endPointSource1 = EndPointFactory.MakeEndPointSource(
                 UdpListeners.EndpointA,
                 null);
 
-            var endPointSource2 = EndpointParser.MakeEndPointSource(
+            var endPointSource2 = EndPointFactory.MakeEndPointSource(
                 UdpListeners.EndpointB,
                 null);
             
@@ -93,11 +93,11 @@ namespace JustEat.StatsD
         public static void EndpointSwitchShouldNotCauseExceptionsParallel()
         {
             // Arrange
-            var endPointSource1 = EndpointParser.MakeEndPointSource(
+            var endPointSource1 = EndPointFactory.MakeEndPointSource(
                 UdpListeners.EndpointA,
                 null);
 
-            var endPointSource2 = EndpointParser.MakeEndPointSource(
+            var endPointSource2 = EndPointFactory.MakeEndPointSource(
                 UdpListeners.EndpointB,
                 null);
             


### PR DESCRIPTION
Rename `EndpointParser` to `EndPointFactory`.

Resolves #154.
