### PR TITLE
version metadata for 4.0 beta 01

### DIFF
--- a/version.props
+++ b/version.props
@@ -3,7 +3,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <VersionPrefix>4.0.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionSuffix>beta-01</VersionSuffix>
 
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$(APPVEYOR_BUILD_NUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Prepare for a beta of `4.0.0`. Final docs will be done when this beta has been used in 1 or more places.  

This PR generates `JustEat.StatsD.4.0.0-beta-01-build569.nupkg` [over here](https://ci.appveyor.com/project/justeattech/justeat-statsd/builds/21094058)

So I think, before we push to nuget, we would merge and tag?


_Please include a reference to a GitHub issue if appropriate._

