### PR TITLE
Simpler AWS lambda example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,9 @@ services.AddStatsD(
 
         return new StatsDConfiguration
         {
-            Host = options.HostName,
-            Port = options.Port,
             Prefix = options.Prefix,
-            SocketProtocol = SocketProtocol.IP,
-            OnError = ex => LogError(ex)
+            Host = options.HostName,
+            SocketProtocol = SocketProtocol.IP
         };
     });
 ```


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Simpler AWS lambda example, setting only the values that are typically set.
The full example could imply that e.g. `Port` must be set, whereas this is seldom to never necessary in our experience.

_Please include a reference to a GitHub issue if appropriate._
