### PR TITLE
Add Code Coverage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.3" PrivateAssets="All" />
+    <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" Version="4.0.11" PrivateAssets="All" />
     <PackageReference Include="Text.Analyzers" Version="2.6.3" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | | Linux | Windows |
 |:-:|:-:|:-:|
-| **Build Status** | [![Build status](https://img.shields.io/travis/justeat/JustEat.StatsD/master.svg)](https://travis-ci.org/justeat/JustEat.StatsD) | [![Build status](https://img.shields.io/appveyor/ci/justeattech/justeat-statsd/master.svg)](https://ci.appveyor.com/project/justeattech/justeat-statsd) |
+| **Build Status** | [![Build status](https://img.shields.io/travis/justeat/JustEat.StatsD/master.svg)](https://travis-ci.org/justeat/JustEat.StatsD) | [![Build status](https://img.shields.io/appveyor/ci/justeattech/justeat-statsd/master.svg)](https://ci.appveyor.com/project/justeattech/justeat-statsd) [![codecov](https://codecov.io/gh/justeat/JustEat.StatsD/branch/master/graph/badge.svg)](https://codecov.io/gh/justeat/JustEat.StatsD) |
 | **Build History** | [![Build history](https://buildstats.info/travisci/chart/justeat/JustEat.StatsD?branch=master&includeBuildsFromPullRequest=false)](https://travis-ci.org/justeat/JustEat.StatsD) |  [![Build history](https://buildstats.info/appveyor/chart/justeattech/justeat-statsd?branch=master&includeBuildsFromPullRequest=false)](https://ci.appveyor.com/project/justeattech/justeat-statsd) |
 
 ## Summary

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ install:
   - ps: .\SetAppVeyorBuildVersion.ps1
 build_script:
   - ps: .\Build.ps1
+after_build:
+  - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
+  - pip install codecov
+  - codecov -f "artifacts\code-coverage.xml"
 artifacts:
 - path: '**\$(APPVEYOR_PROJECT_NAME)*.nupkg'
   name: Nuget


### PR DESCRIPTION
  * Collect code coverage (on Windows) using OpenCover and report it to codecov.io now that .NET Core portable PDBs are supported.
  * Use ReportGenerator to produce human-readable HTML coverage reports.
