### PR TITLE
Allow IEndpointSource to return null Endpoint

### DIFF
--- a/src/JustEat.StatsD/SocketTransport.cs
+++ b/src/JustEat.StatsD/SocketTransport.cs
@@ -44,7 +44,13 @@ namespace JustEat.StatsD
                 return;
             }
 
-            var pool = GetPool(_endpointSource.GetEndpoint());
+            var endpoint = _endpointSource.GetEndpoint();
+            if (endpoint == null)
+            {
+                return;
+            }
+
+            var pool = GetPool(endpoint);
             var socket = pool.PopOrCreate();
 
             try

--- a/tests/JustEat.StatsD.Tests/SocketTransportTests.cs
+++ b/tests/JustEat.StatsD.Tests/SocketTransportTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using JustEat.StatsD.EndpointLookups;
+using Moq;
 using Shouldly;
 using Xunit;
 
@@ -69,6 +70,17 @@ namespace JustEat.StatsD
             using (var transport = new SocketTransport(LocalStatsEndpoint(), SocketProtocol.IP))
             {
                 transport.Send(new ArraySegment<byte>(Array.Empty<byte>()));
+            }
+        }
+
+        [Fact]
+        public static void SocketTransportIsNoopForNullEndpoint()
+        {
+            var endpointSource = Mock.Of<IEndPointSource>();
+
+            using (var transport = new SocketTransport(endpointSource, SocketProtocol.IP))
+            {
+                transport.Send("teststat:1|c");
             }
         }
 


### PR DESCRIPTION
Let IEndpointSource return a null Endpoint during sending metrics
to allow them to be skipped.

Resolves #171
