### PR TITLE
Update the analysers to 2.9.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,12 +2,11 @@
  <Import Project="version.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.9.1" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="4.0.11" PrivateAssets="All" />
-    <PackageReference Include="Text.Analyzers" Version="2.6.3" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/tests/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
+++ b/tests/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
@@ -91,7 +91,7 @@ namespace JustEat.StatsD.Extensions
                     timer.Bucket = "changedValue";
                 }
             }
-            catch (Exception)
+            catch (InvalidOperationException)
             {
                 failCount++;
             }
@@ -108,7 +108,7 @@ namespace JustEat.StatsD.Extensions
 
         private static void Fail()
         {
-            throw new Exception("Deliberate fail");
+            throw new InvalidOperationException("Deliberate fail");
         }
     }
 }


### PR DESCRIPTION
_Summarise the changes this Pull Request makes._

Update the analysers to version 2.9.1
remove `Text.Analyzers` as it is deprecated
and be more specific about exception types in a test (analysers now require it)

_Please include a reference to a GitHub issue if appropriate._
