### PR TITLE
Add public API analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,10 +6,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
     <PackageReference Include="ReportGenerator" Version="4.2.15" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,20 +1,21 @@
 <Project>
   <Import Project="version.props" />
   <PropertyGroup>
-    <AnalyzersVersion>2.9.2</AnalyzersVersion>
+    <AnalyzersVersion>2.9.4</AnalyzersVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NetCore.Analyzers" Version="$(AnalyzersVersion)" PrivateAssets="All" />
     <PackageReference Include="OpenCover" Version="4.7.922" PrivateAssets="All" />
-    <PackageReference Include="ReportGenerator" Version="4.1.9" PrivateAssets="All" />
+    <PackageReference Include="ReportGenerator" Version="4.2.15" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)justeat-oss.snk</AssemblyOriginatorKeyFile>
     <Authors>JUSTEAT_OSS</Authors>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)JustEat.StatsD.ruleset</CodeAnalysisRuleSet>
     <Company>Just Eat</Company>
     <Copyright>Copyright (c) Just Eat 2015-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/JustEat.StatsD.ruleset
+++ b/JustEat.StatsD.ruleset
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="JustEat.StatsD Rules" Description="This rule set contains rules for the Just Eat JustEat.StatsD solution." ToolsVersion="16.0">
+  <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1303" Action="None" />
+  </Rules>
+</RuleSet>

--- a/JustEat.StatsD.sln
+++ b/JustEat.StatsD.sln
@@ -1,6 +1,7 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{06BE4D4A-B0DF-465D-9BAC-6CC3C9779A37}"
 	ProjectSection(SolutionItems) = preProject
@@ -13,12 +14,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{06BE4D
 		build.sh = build.sh
 		CHANGELOG.md = CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
+		JustEat.StatsD.ruleset = JustEat.StatsD.ruleset
 		LICENSE = LICENSE
 		README.md = README.md
-		version.props = version.props
-		Directory.Build.targets = Directory.Build.targets
 		ReferenceAssemblies.props = ReferenceAssemblies.props
+		version.props = version.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustEat.StatsD", "src\JustEat.StatsD\JustEat.StatsD.csproj", "{6A338D71-E28B-455A-9E9D-3667EE659542}"

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -21,4 +21,8 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net451' ">
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
 </Project>

--- a/src/JustEat.StatsD/PublicAPI.Shipped.txt
+++ b/src/JustEat.StatsD/PublicAPI.Shipped.txt
@@ -1,0 +1,83 @@
+JustEat.StatsD.EndpointLookups.CachedEndpointSource
+JustEat.StatsD.EndpointLookups.CachedEndpointSource.CachedEndpointSource(JustEat.StatsD.EndpointLookups.IEndPointSource inner, System.TimeSpan cacheDuration) -> void
+JustEat.StatsD.EndpointLookups.CachedEndpointSource.GetEndpoint() -> System.Net.EndPoint
+JustEat.StatsD.EndpointLookups.DnsLookupIpEndpointSource
+JustEat.StatsD.EndpointLookups.DnsLookupIpEndpointSource.DnsLookupIpEndpointSource(string hostName, int port) -> void
+JustEat.StatsD.EndpointLookups.DnsLookupIpEndpointSource.GetEndpoint() -> System.Net.EndPoint
+JustEat.StatsD.EndpointLookups.EndPointFactory
+JustEat.StatsD.EndpointLookups.IEndPointSource
+JustEat.StatsD.EndpointLookups.IEndPointSource.GetEndpoint() -> System.Net.EndPoint
+JustEat.StatsD.EndpointLookups.SimpleEndpointSource
+JustEat.StatsD.EndpointLookups.SimpleEndpointSource.GetEndpoint() -> System.Net.EndPoint
+JustEat.StatsD.EndpointLookups.SimpleEndpointSource.SimpleEndpointSource(System.Net.EndPoint value) -> void
+JustEat.StatsD.IDisposableTimer
+JustEat.StatsD.IDisposableTimer.Bucket.get -> string
+JustEat.StatsD.IDisposableTimer.Bucket.set -> void
+JustEat.StatsD.IStatsDPublisher
+JustEat.StatsD.IStatsDPublisher.Gauge(double value, string bucket) -> void
+JustEat.StatsD.IStatsDPublisher.Increment(long value, double sampleRate, string bucket) -> void
+JustEat.StatsD.IStatsDPublisher.Timing(long duration, double sampleRate, string bucket) -> void
+JustEat.StatsD.IStatsDPublisherExtensions
+JustEat.StatsD.IStatsDTransport
+JustEat.StatsD.IStatsDTransport.Send(in System.ArraySegment<byte> metric) -> void
+JustEat.StatsD.IStatsDTransportExtensions
+JustEat.StatsD.SocketProtocol
+JustEat.StatsD.SocketProtocol.IP = 1 -> JustEat.StatsD.SocketProtocol
+JustEat.StatsD.SocketProtocol.Udp = 0 -> JustEat.StatsD.SocketProtocol
+JustEat.StatsD.SocketTransport
+JustEat.StatsD.SocketTransport.Dispose() -> void
+JustEat.StatsD.SocketTransport.Send(in System.ArraySegment<byte> metric) -> void
+JustEat.StatsD.SocketTransport.SocketTransport(JustEat.StatsD.EndpointLookups.IEndPointSource endPointSource, JustEat.StatsD.SocketProtocol socketProtocol) -> void
+JustEat.StatsD.StatsDConfiguration
+JustEat.StatsD.StatsDConfiguration.DnsLookupInterval.get -> System.TimeSpan?
+JustEat.StatsD.StatsDConfiguration.DnsLookupInterval.set -> void
+JustEat.StatsD.StatsDConfiguration.Host.get -> string
+JustEat.StatsD.StatsDConfiguration.Host.set -> void
+JustEat.StatsD.StatsDConfiguration.OnError.get -> System.Func<System.Exception, bool>
+JustEat.StatsD.StatsDConfiguration.OnError.set -> void
+JustEat.StatsD.StatsDConfiguration.Port.get -> int
+JustEat.StatsD.StatsDConfiguration.Port.set -> void
+JustEat.StatsD.StatsDConfiguration.Prefix.get -> string
+JustEat.StatsD.StatsDConfiguration.Prefix.set -> void
+JustEat.StatsD.StatsDConfiguration.SocketProtocol.get -> JustEat.StatsD.SocketProtocol
+JustEat.StatsD.StatsDConfiguration.SocketProtocol.set -> void
+JustEat.StatsD.StatsDConfiguration.StatsDConfiguration() -> void
+JustEat.StatsD.StatsDPublisher
+JustEat.StatsD.StatsDPublisher.Dispose() -> void
+JustEat.StatsD.StatsDPublisher.Gauge(double value, string bucket) -> void
+JustEat.StatsD.StatsDPublisher.Increment(long value, double sampleRate, string bucket) -> void
+JustEat.StatsD.StatsDPublisher.StatsDPublisher(JustEat.StatsD.StatsDConfiguration configuration) -> void
+JustEat.StatsD.StatsDPublisher.StatsDPublisher(JustEat.StatsD.StatsDConfiguration configuration, JustEat.StatsD.IStatsDTransport transport) -> void
+JustEat.StatsD.StatsDPublisher.Timing(long duration, double sampleRate, string bucket) -> void
+JustEat.StatsD.StatsDServiceCollectionExtensions
+JustEat.StatsD.TimerExtensions
+const JustEat.StatsD.StatsDConfiguration.DefaultPort = 8125 -> int
+static JustEat.StatsD.EndpointLookups.EndPointFactory.MakeEndPointSource(System.Net.EndPoint endpoint, System.TimeSpan? endpointCacheDuration) -> JustEat.StatsD.EndpointLookups.IEndPointSource
+static JustEat.StatsD.EndpointLookups.EndPointFactory.MakeEndPointSource(string host, int port, System.TimeSpan? endpointCacheDuration) -> JustEat.StatsD.EndpointLookups.IEndPointSource
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher publisher, long value, double sampleRate, System.Collections.Generic.IEnumerable<string> buckets) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher publisher, long value, double sampleRate, params string[] buckets) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher publisher, long value, double sampleRate, string bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher publisher, long value, string bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher publisher, string bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher publisher, long value, double sampleRate, System.Collections.Generic.IEnumerable<string> buckets) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher publisher, long value, double sampleRate, params string[] buckets) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher publisher, long value, string bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher publisher, string bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher publisher, System.TimeSpan duration, double sampleRate, string bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher publisher, System.TimeSpan duration, string bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher publisher, long duration, string bucket) -> void
+static JustEat.StatsD.IStatsDTransportExtensions.Send(this JustEat.StatsD.IStatsDTransport transport, System.Collections.Generic.IEnumerable<string> metrics) -> void
+static JustEat.StatsD.IStatsDTransportExtensions.Send(this JustEat.StatsD.IStatsDTransport transport, string metric) -> void
+static JustEat.StatsD.StatsDConfiguration.DefaultDnsLookupInterval.get -> System.TimeSpan
+static JustEat.StatsD.StatsDServiceCollectionExtensions.AddStatsD(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static JustEat.StatsD.StatsDServiceCollectionExtensions.AddStatsD(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Func<System.IServiceProvider, JustEat.StatsD.StatsDConfiguration> configurationFactory) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static JustEat.StatsD.StatsDServiceCollectionExtensions.AddStatsD(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, string host, string prefix = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+static JustEat.StatsD.TimerExtensions.StartTimer(this JustEat.StatsD.IStatsDPublisher publisher, string bucket) -> JustEat.StatsD.IDisposableTimer
+static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher publisher, string bucket, System.Action action) -> void
+static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher publisher, string bucket, System.Action<JustEat.StatsD.IDisposableTimer> action) -> void
+static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher publisher, string bucket, System.Func<JustEat.StatsD.IDisposableTimer, System.Threading.Tasks.Task> action) -> System.Threading.Tasks.Task
+static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher publisher, string bucket, System.Func<System.Threading.Tasks.Task> action) -> System.Threading.Tasks.Task
+static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher publisher, string bucket, System.Func<JustEat.StatsD.IDisposableTimer, System.Threading.Tasks.Task<T>> func) -> System.Threading.Tasks.Task<T>
+static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher publisher, string bucket, System.Func<JustEat.StatsD.IDisposableTimer, T> func) -> T
+static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher publisher, string bucket, System.Func<System.Threading.Tasks.Task<T>> func) -> System.Threading.Tasks.Task<T>
+static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher publisher, string bucket, System.Func<T> func) -> T

--- a/src/JustEat.StatsD/SocketTransport.cs
+++ b/src/JustEat.StatsD/SocketTransport.cs
@@ -50,7 +50,10 @@ namespace JustEat.StatsD
                 return;
             }
 
+#pragma warning disable CA2000
             var pool = GetPool(endpoint);
+#pragma warning restore CA2000
+
             var socket = pool.PopOrCreate();
 
             try

--- a/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="Moq" Version="4.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/tests/JustEat.StatsD.Tests/SocketTransportTests.cs
+++ b/tests/JustEat.StatsD.Tests/SocketTransportTests.cs
@@ -22,8 +22,10 @@ namespace JustEat.StatsD
         public static void SocketTransportCanSendOverUdpWithoutError()
         {
             // using block not used here so the finalizer gets some code coverage
-            var transport = new SocketTransport(LocalStatsEndpoint(), SocketProtocol.Udp);
-            transport.Send("teststat:1|c");
+            using (var transport = new SocketTransport(LocalStatsEndpoint(), SocketProtocol.Udp))
+            {
+                transport.Send("teststat:1|c");
+            }
         }
 
         [Fact]

--- a/tests/JustEat.StatsD.Tests/StatsDPublisherTests.cs
+++ b/tests/JustEat.StatsD.Tests/StatsDPublisherTests.cs
@@ -18,16 +18,17 @@ namespace JustEat.StatsD
                 Prefix = "red",
             };
 
-            var publisher = new StatsDPublisher(config, mock.Object);
-
-            // Act
-            publisher.Decrement(10, "black");
-            publisher.Decrement(-10, "yellow");
-            publisher.Decrement(10, 1, "pink");
-            publisher.Decrement(-10, 1, "orange");
-            publisher.Decrement(10, 1, new[] { "white", "blue" });
-            publisher.Decrement(10, 1, new List<string>() { "green", "red" });
-            publisher.Decrement(10, 1, null as IEnumerable<string>);
+            using (var publisher = new StatsDPublisher(config, mock.Object))
+            {
+                // Act
+                publisher.Decrement(10, "black");
+                publisher.Decrement(-10, "yellow");
+                publisher.Decrement(10, 1, "pink");
+                publisher.Decrement(-10, 1, "orange");
+                publisher.Decrement(10, 1, new[] { "white", "blue" });
+                publisher.Decrement(10, 1, new List<string>() { "green", "red" });
+                publisher.Decrement(10, 1, null as IEnumerable<string>);
+            }
 
             // Assert
             mock.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Exactly(8));
@@ -44,16 +45,17 @@ namespace JustEat.StatsD
                 Prefix = "red",
             };
 
-            var publisher = new StatsDPublisher(config, mock.Object);
-
-            // Act
-            publisher.Increment(10, "black");
-            publisher.Increment(-10, "yellow");
-            publisher.Increment(10, 1, "pink");
-            publisher.Increment(-10, 1, "orange");
-            publisher.Increment(10, 1, new[] { "white", "blue" });
-            publisher.Increment(10, 1, new List<string>() { "green", "red" });
-            publisher.Increment(10, 1, null as IEnumerable<string>);
+            using (var publisher = new StatsDPublisher(config, mock.Object))
+            {
+                // Act
+                publisher.Increment(10, "black");
+                publisher.Increment(-10, "yellow");
+                publisher.Increment(10, 1, "pink");
+                publisher.Increment(-10, 1, "orange");
+                publisher.Increment(10, 1, new[] { "white", "blue" });
+                publisher.Increment(10, 1, new List<string>() { "green", "red" });
+                publisher.Increment(10, 1, null as IEnumerable<string>);
+            }
 
             // Assert
             mock.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Exactly(8));
@@ -66,23 +68,24 @@ namespace JustEat.StatsD
             var mock = new Mock<IStatsDTransport>();
             var config = new StatsDConfiguration();
 
-            var publisher = new StatsDPublisher(config, mock.Object);
-
-            // Act
-            publisher.Decrement(-1, 1, null as string[]);
-            publisher.Increment(-1, 1, null as string[]);
-            publisher.Decrement(1, 1, null as string[]);
-            publisher.Increment(1, 1, null as string[]);
-            publisher.Decrement(1, 1, Array.Empty<string>());
-            publisher.Increment(1, 1, Array.Empty<string>());
-            publisher.Decrement(-1, 1, Array.Empty<string>());
-            publisher.Increment(-1, 1, Array.Empty<string>());
-            publisher.Decrement(-1, 1, new List<string>());
-            publisher.Increment(-1, 1, new List<string>());
-            publisher.Decrement(1, 1, null as IEnumerable<string>);
-            publisher.Increment(1, 1, null as IEnumerable<string>);
-            publisher.Decrement(1, 1, new[] { string.Empty });
-            publisher.Increment(1, 1, new[] { string.Empty });
+            using (var publisher = new StatsDPublisher(config, mock.Object))
+            {
+                // Act
+                publisher.Decrement(-1, 1, null as string[]);
+                publisher.Increment(-1, 1, null as string[]);
+                publisher.Decrement(1, 1, null as string[]);
+                publisher.Increment(1, 1, null as string[]);
+                publisher.Decrement(1, 1, Array.Empty<string>());
+                publisher.Increment(1, 1, Array.Empty<string>());
+                publisher.Decrement(-1, 1, Array.Empty<string>());
+                publisher.Increment(-1, 1, Array.Empty<string>());
+                publisher.Decrement(-1, 1, new List<string>());
+                publisher.Increment(-1, 1, new List<string>());
+                publisher.Decrement(1, 1, null as IEnumerable<string>);
+                publisher.Increment(1, 1, null as IEnumerable<string>);
+                publisher.Decrement(1, 1, new[] { string.Empty });
+                publisher.Increment(1, 1, new[] { string.Empty });
+            }
 
             // Assert
             mock.Verify((p) => p.Send(It.IsAny<ArraySegment<byte>>()), Times.Never());
@@ -95,11 +98,12 @@ namespace JustEat.StatsD
             var mock = new Mock<IStatsDTransport>();
             var config = new StatsDConfiguration();
 
-            var publisher = new StatsDPublisher(config, mock.Object);
-
-            // Act
-            publisher.Decrement(1, 0, new[] { "foo" });
-            publisher.Increment(1, 0, new[] { "bar" });
+            using (var publisher = new StatsDPublisher(config, mock.Object))
+            {
+                // Act
+                publisher.Decrement(1, 0, new[] { "foo" });
+                publisher.Increment(1, 0, new[] { "bar" });
+            }
 
             // Assert
             mock.Verify((p) => p.Send(It.IsAny<ArraySegment<byte>>()), Times.Never());


### PR DESCRIPTION
  * Add Roslyn analyzers for public API surface.
  * Remove redundant NuGet package reference.
  * Update (most) NuGet packages to their latest versions.
  * Fix (or suppress) code analysis warnings.
