### PR TITLE
Ignore Dependabot branches in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,3 +20,6 @@ artifacts:
 - path: artifacts\coverage*.xml
   name: 'Code Coverage'
 test: off
+branches:
+  except:
+    - /dependabot/nuget/*


### PR DESCRIPTION
Do not build Dependabot branches in AppVeyor CI, otherwise there's two builds, one for the branch and one for the PR.
