### PR TITLE
Adjust required coverage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,6 +48,6 @@
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[Benchmark]*,[*.Tests]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
-    <Threshold>90</Threshold>
+    <Threshold>85</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Reduce the required code coverage slightly, as sometimes the branch coverage dips below 90% due to some of the randomness in the integration tests and causes the Linux build to fail.
