### PR TITLE
Support .NET 5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,6 @@
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <NoWarn>$(NoWarn);NU5104</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,11 +19,12 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageVersion Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(AssemblyName)' == 'JustEat.StatsD' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.1.*" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.StatsD' ">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.1.*" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.1.*" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,11 +20,11 @@
     <PackageVersion Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.2.20475.5" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.StatsD' ">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.2.20475.5" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.2.20475.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,11 +20,11 @@
     <PackageVersion Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.1.*" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.2.20475.5" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.StatsD' ">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.1.*" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.1.*" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0-rc.2.20475.5" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0-rc.2.20475.5" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />

--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ We use this library within our components to publish [StatsD](http://github.com/
 
 ### Supported platforms
 
-`JustEat.StatsD` version 4.1.0 is built for these target frameworks:
+`JustEat.StatsD` version 4.2.0 is built for these target frameworks:
 
 * `net461`
 * `netstandard2.0`
 * `netstandard2.1`
 * `netcoreapp2.1`
+* `net5.0`
 
 ### Features
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100-rc.2.20479.15",
+    "version": "5.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100-rc.1.20452.10",
+    "version": "5.0.100-rc.2.20479.15",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.403",
+    "version": "5.0.100-rc.1.20452.10",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/JustEat.StatsD/ConnectedSocketPool.cs
+++ b/src/JustEat.StatsD/ConnectedSocketPool.cs
@@ -48,7 +48,7 @@ namespace JustEat.StatsD
         /// <returns>An object from the pool. </returns>
         private Socket? Pop()
         {
-            if (_pool.TryTake(out Socket result))
+            if (_pool.TryTake(out Socket? result))
             {
                 return result;
             }

--- a/src/JustEat.StatsD/EndpointLookups/EndPointFactory.cs
+++ b/src/JustEat.StatsD/EndpointLookups/EndPointFactory.cs
@@ -57,7 +57,7 @@ namespace JustEat.StatsD.EndpointLookups
 
             IEndPointSource source;
 
-            if (IPAddress.TryParse(host, out IPAddress address))
+            if (IPAddress.TryParse(host, out IPAddress? address))
             {
                 // If we were given an IP instead of a hostname,
                 // we can happily keep it the life of this class

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -7,7 +7,7 @@
     <PackageId>JustEat.StatsD</PackageId>
     <RootNamespace>JustEat.StatsD</RootNamespace>
     <Summary>A .NET library for publishing metrics to StatsD.</Summary>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />

--- a/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1707;CA2007</NoWarn>
     <RootNamespace>JustEat.StatsD</RootNamespace>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\JustEat.StatsD\JustEat.StatsD.csproj" />

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.2.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>


### PR DESCRIPTION
Add support for .NET 5.0 with an explicit `net5.0` TFM.

Resolves #273.
