### PR TITLE
Update .NET SDK release channel

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -17,4 +17,4 @@ jobs:
 
     - name: Update .NET SDK
       shell: pwsh
-      run: ./update-dotnet-sdk.ps1 -Channel "3.1" -GitHubToken ${{ secrets.GITHUB_TOKEN }} -UserName "github-actions[bot]" -UserEmail "github-actions[bot]@users.noreply.github.com"
+      run: ./update-dotnet-sdk.ps1 -Channel "5.0" -GitHubToken ${{ secrets.GITHUB_TOKEN }} -UserName "github-actions[bot]" -UserEmail "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Update from the `3.1` release channel to `5.0` for keeping the SDK up-to-date.

