### PR TITLE
Tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ var config = new StatsDConfiguration
 
 ##### Extending tags formatter
 
-As tags are not part of the StatsD specification, the `IStatsDTagsFormatter` used can be extended and injected in the `StatsDConfiguration`.
+As tags are not part of the StatsD specification, the `IStatsDTagsFormatter` used can be extended and specified by the `StatsDConfiguration`.
 
 The template class `StatsDTagsFormatter` can be inherited from providing the `StatsDTagsFormatterConfiguration`:
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ var config = new StatsDConfiguration
 
 As tags are not part of the StatsD specification, the `IStatsDTagsFormatter` used can be extended and injected in the `StatsDConfiguration`.
 
-The template class `StatsDTagsFormatter` can be inherited providing the `StatsDTagsFormatterConfiguration`:
+The template class `StatsDTagsFormatter` can be inherited from providing the `StatsDTagsFormatterConfiguration`:
 
 * **Prefix**: the string that will appear before the tag(s).
 * **Suffix**: the string that will appear after the tag(s).

--- a/README.md
+++ b/README.md
@@ -22,15 +22,16 @@ We use this library within our components to publish [StatsD](http://github.com/
 
 ### Features
 
-* Easy to use
-* Robust and proven
+* Easy to use.
+* Robust and proven.
 * Tuned for high performance and low resource usage using [BenchmarkDotNet](https://benchmarkdotnet.org/). Typically zero allocation on sending a metric on target frameworks where `Span<T>` is available.
 * Works well with modern .NET apps - `async ... await`, .NET Core, .NET Standard 2.0.
 * Supports standard StatsD primitives: `Increment`, `Decrement`, `Timing` and `Gauge`.
+* Supports tagging on `Increment`, `Decrement`, `Timing` and `Gauge`.
 * Supports sample rate for cutting down of sends of high-volume metrics.
 * Helpers to make it easy to time a delegate such as a `Func<T>` or `Action<T>`, or a code block inside a `using` statement.
-* Send stats over UDP or IP
-* Send stats to a server by name or IP address
+* Send stats over UDP or IP.
+* Send stats to a server by name or IP address.
 
 #### Publishing statistics
 
@@ -143,15 +144,16 @@ Bind<StatsDConfiguration>().ToConstant(statsDConfig>);
 Bind<IStatsDPublisher>().To<StatsDPublisher>().InSingletonScope();
 ```
 
-## StatsDConfiguration fields
+### StatsDConfiguration fields
 
 | Name              | Type                    | Default                        | Comments                                                                                                |
 |-------------------|-------------------------|--------------------------------|---------------------------------------------------------------------------------------------------------|
 | Host              | `string`                |                                | The host name or IP address of the StatsD server. There is no default, this must be set.                |
 | Port              | `int`                   | `8125`                         | The StatsD port.                                                                                        |
 | DnsLookupInterval | `TimeSpan?`             | `5 minutes`                    | Length of time to cache the host name to IP address lookup. Only used when "Host" contains a host name. |
-| Prefix            | `string`                | `string.Empty`                 | Prepend a prefix to all stats.
-| SocketProtocol    | `SocketProtocol`, one of `Udp`, `IP`| `Udp`              | Type of socket to use when sending stats to the server.                                                                          |
+| Prefix            | `string`                | `string.Empty`                 | Prepend a prefix to all stats.                                                                          |
+| SocketProtocol    | `SocketProtocol`, one of `Udp`, `IP`| `Udp`              | Type of socket to use when sending stats to the server.                                                 |
+| TagsFormatter     | `IStatsDTagsFormatter`  | `NoOpTagsFormatter`            | Format used for tags for the different providers. Out-of-the-box formatters can be accessed using the `TagsFormatter` class. |
 | OnError           | `Func<Exception, bool>` | `null`                         | Function to receive notification of any exceptions.                                                     |
 
 `OnError` is a function to receive notification of any errors that occur when trying to publish a metric. This function should return:
@@ -161,7 +163,39 @@ Bind<IStatsDPublisher>().To<StatsDPublisher>().InSingletonScope();
 
 The default behaviour is to ignore the error.
 
-#### Example of using the interface
+#### Tagging support
+
+Tags or dimensions are not covered by the StatsD specification. Providers supporting tags have implemented their flavours. Some of the major providers are supported out-of-the-box:
+
+* [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-statsd.html).
+* [DataDog](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics)
+* [InfluxDB](https://www.influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb/#introducing-influx-statsd).
+* [Librato](https://github.com/librato/statsd-librato-backend#tags).
+* [SignalFX](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-statsd.html#adding-dimensions-to-statsd-metrics).
+* [Splunk](https://docs.splunk.com/Documentation/Splunk/8.0.5/Metrics/GetMetricsInStatsd).
+
+```csharp
+var config = new StatsDConfiguration
+{
+    Prefix = "prefix",
+    Host = "127.0.0.1",
+    TagsFormatter = TagsFormatter.CloudWatch,
+};
+```
+
+##### Extending tags formatter
+
+As tags are not part of the StatsD specification, the `IStatsDTagsFormatter` used can be extended and injected in the `StatsDConfiguration`.
+
+The template class `StatsDTagsFormatter` can be inherited providing the `StatsDTagsFormatterConfiguration`:
+
+* **Prefix**: the string that will appear before the tag(s).
+* **Suffix**: the string that will appear after the tag(s).
+* **AreTrailing**: a boolean indicating if the tag(s) are placed at the end of the StatsD message (like it is supported by AWS CloudWatch, DataDog or Splunk) or otherwise they are right after the bucket name (like it is supported by InfluxDB, Librato or SignalFX).
+* **TagsSeparator**: the string that will be placed between tags.
+* **KeyValueSeparator**: the string that will be placed between the tag key and its value.
+
+### Example of using the interface
 
 Given an existing instance of `IStatsDPublisher` called `stats` you can do for e.g.:
 
@@ -176,7 +210,7 @@ var statName = "DoSomething." + success ? "Success" : "Failure";
 stats.Timing(statName, stopWatch.Elapsed);
 ```
 
-#### Simple timers
+### Simple timers
 
 This syntax for timers less typing in simple cases, where you always want to time the operation, and always with the same stat name. Given an existing instance of `IStatsDPublisher` you can do:
 
@@ -197,7 +231,7 @@ using (stats.StartTimer("someStat"))
 The `StartTimer` returns an `IDisposableTimer` that wraps a stopwatch and implements `IDisposable`.
 The stopwatch is automatically stopped and the metric sent when it falls out of scope and is disposed on the closing `}` of the `using` statement.
 
-##### Changing the name of simple timers
+#### Changing the name of simple timers
 
 Sometimes the decision of which stat to send should not be taken before the operation completes. e.g. When you are timing http operations and want different status codes to be logged under different stats.
 
@@ -214,7 +248,7 @@ using (var timer = stats.StartTimer("SomeHttpOperation."))
 }
 ```
 
-##### Functional style
+#### Functional style
 
 ```csharp
 //  timing an action without a return value:
@@ -228,9 +262,9 @@ await stats.Time("someStat", async t => await DoSomethingAsync());
 var result = await stats.Time("someStat", async t => await GetSomethingAsync());
 ```
 
-In all these cases the function or delegate is supplied with a `IDisposableTimer t` so that the stat name can be changed if need be.
+In all these cases the function or delegate is supplied with an `IDisposableTimer t` so that the stat name can be changed if need be.
 
-##### Credits
+#### Credits
 
 The idea of "disposable timers" for using statements is an old one, see for example [this StatsD client](https://github.com/Pereingo/statsd-csharp-client) and [MiniProfiler](https://miniprofiler.com/dotnet/HowTo/ProfileCode).
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The default behaviour is to ignore the error.
 
 #### Tagging support
 
-Tags or dimensions are not covered by the StatsD specification. Providers supporting tags have implemented their flavours. Some of the major providers are supported out-of-the-box:
+Tags or dimensions are not covered by the StatsD specification. Providers supporting tags have implemented their own flavours. Some of the major providers are supported out-of-the-box from 5.0.0+ are:
 
 * [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-statsd.html).
 * [DataDog](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics)

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The template class `StatsDTagsFormatter` can be inherited from providing the `St
 
 * **Prefix**: the string that will appear before the tag(s).
 * **Suffix**: the string that will appear after the tag(s).
-* **AreTrailing**: a boolean indicating if the tag(s) are placed at the end of the StatsD message (like it is supported by AWS CloudWatch, DataDog or Splunk) or otherwise they are right after the bucket name (like it is supported by InfluxDB, Librato or SignalFX).
+* **AreTrailing**: a boolean indicating if the tag(s) are placed at the end of the StatsD message (like it is supported by AWS CloudWatch, DataDog and Splunk) or otherwise they are right after the bucket name (like it is supported by InfluxDB, Librato and SignalFX).
 * **TagsSeparator**: the string that will be placed between tags.
 * **KeyValueSeparator**: the string that will be placed between the tag key and its value.
 

--- a/src/JustEat.StatsD/Buffered/Buffer.cs
+++ b/src/JustEat.StatsD/Buffered/Buffer.cs
@@ -2,15 +2,15 @@ using System;
 
 namespace JustEat.StatsD.Buffered
 {
-    internal ref struct Buffer
+    internal ref struct Buffer<T>
     {
-        public Buffer(Span<byte> source)
+        public Buffer(Span<T> source)
         {
             Tail = source;
             Written = 0;
         }
 
-        public Span<byte> Tail;
+        public Span<T> Tail;
         public int Written;
     }
 }

--- a/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace JustEat.StatsD.Buffered
 {
@@ -9,12 +10,12 @@ namespace JustEat.StatsD.Buffered
 
         [ThreadStatic]
         private static byte[]? _buffer;
-        private static byte[] Buffer => _buffer ?? (_buffer = new byte[SafeUdpPacketSize]);
+        private static byte[] Buffer => _buffer ??= new byte[SafeUdpPacketSize];
 
 #pragma warning disable CA5394
         [ThreadStatic]
         private static Random? _random;
-        private static Random Random => _random ?? (_random = new Random());
+        private static Random Random => _random ??= new Random();
 #pragma warning disable CA5394
 
         private readonly StatsDUtf8Formatter _formatter;
@@ -30,22 +31,22 @@ namespace JustEat.StatsD.Buffered
 
             _onError = configuration.OnError;
             _transport = transport;
-            _formatter = new StatsDUtf8Formatter(configuration.Prefix);
+            _formatter = new StatsDUtf8Formatter(configuration.Prefix, configuration.TagsFormatter);
         }
 
-        public void Increment(long value, double sampleRate, string bucket)
+        public void Increment(long value, double sampleRate, string bucket, Dictionary<string, string?>? tags)
         {
-            SendMessage(sampleRate, StatsDMessage.Counter(value, bucket));
+            SendMessage(sampleRate, StatsDMessage.Counter(value, bucket, tags));
         }
 
-        public void Gauge(double value, string bucket)
+        public void Gauge(double value, string bucket, Dictionary<string, string?>? tags)
         {
-            SendMessage(DefaultSampleRate, StatsDMessage.Gauge(value, bucket));
+            SendMessage(DefaultSampleRate, StatsDMessage.Gauge(value, bucket, tags));
         }
 
-        public void Timing(long duration, double sampleRate, string bucket)
+        public void Timing(long duration, double sampleRate, string bucket, Dictionary<string, string?>? tags)
         {
-            SendMessage(sampleRate, StatsDMessage.Timing(duration, bucket));
+            SendMessage(sampleRate, StatsDMessage.Timing(duration, bucket, tags));
         }
 
         private void SendMessage(double sampleRate, in StatsDMessage msg)

--- a/src/JustEat.StatsD/Buffered/BufferExtensions.cs
+++ b/src/JustEat.StatsD/Buffered/BufferExtensions.cs
@@ -10,7 +10,7 @@ namespace JustEat.StatsD.Buffered
     internal static class BufferExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBytes(this ref Buffer src, Span<byte> destination)
+        public static bool TryWrite<T>(this ref Buffer<T> src, ReadOnlySpan<T> destination)
         {
             if (destination.Length > src.Tail.Length)
             {
@@ -23,11 +23,16 @@ namespace JustEat.StatsD.Buffered
             return true;
         }
 
-        public static bool TryWriteUtf8String(this ref Buffer src, string str)
+        public static bool TryWriteUtf8String(this ref Buffer<byte> src, string str)
         {
+            if (string.IsNullOrEmpty(str))
+            {
+                return true;
+            }
+
 #if NETSTANDARD2_0 || NET461
             var bucketBytes = Encoding.UTF8.GetBytes(str);
-            return src.TryWriteBytes(bucketBytes);
+            return src.TryWrite(bucketBytes);
 #else
             int written = 0;
             try
@@ -47,8 +52,37 @@ namespace JustEat.StatsD.Buffered
 #endif
         }
 
+        public static bool TryWriteUtf8Chars(this ref Buffer<byte> src, ReadOnlySpan<char> chars)
+        {
+            if (chars.Length == 0)
+            {
+                return true;
+            }
+
+#if NETSTANDARD2_0 || NET461
+            var bytes = Encoding.UTF8.GetBytes(chars.ToArray());
+            return src.TryWrite(bytes);
+#else
+            int written = 0;
+            try
+            {
+                written = Encoding.UTF8.GetBytes(chars, src.Tail);
+            }
+#pragma warning disable CA1031
+            catch (ArgumentException)
+#pragma warning restore CA1031
+            {
+                return false;
+            }
+
+            src.Tail = src.Tail.Slice(written);
+            src.Written += written;
+            return true;
+#endif
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteByte(this ref Buffer src, byte ch)
+        public static bool TryWrite<T>(this ref Buffer<T> src, T ch)
         {
             const int OneByte = 1;
             if (src.Tail.Length < OneByte)
@@ -64,7 +98,7 @@ namespace JustEat.StatsD.Buffered
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBytes(this ref Buffer src, byte ch1, byte ch2)
+        public static bool TryWrite<T>(this ref Buffer<T> src, T ch1, T ch2)
         {
             const int TwoBytes = 2;
             if (src.Tail.Length < TwoBytes)
@@ -81,7 +115,7 @@ namespace JustEat.StatsD.Buffered
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBytes(this ref Buffer src, byte ch1, byte ch2, byte ch3)
+        public static bool TryWrite<T>(this ref Buffer<T> src, T ch1, T ch2, T ch3)
         {
             const int ThreeBytes = 3;
             if (src.Tail.Length < ThreeBytes)
@@ -99,7 +133,7 @@ namespace JustEat.StatsD.Buffered
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteInt64(this ref Buffer src, long val)
+        public static bool TryWriteInt64(this ref Buffer<byte> src, long val)
         {
             if (!Utf8Formatter.TryFormat(val, src.Tail, out var consumed))
             {
@@ -113,7 +147,7 @@ namespace JustEat.StatsD.Buffered
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteDouble(this ref Buffer src, double val)
+        public static bool TryWriteDouble(this ref Buffer<byte> src, double val)
         {
             if (!Utf8Formatter.TryFormat((decimal)val, src.Tail, out var consumed))
             {
@@ -125,5 +159,9 @@ namespace JustEat.StatsD.Buffered
 
             return true;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteString(this ref Buffer<char> src, string str) =>
+            TryWrite(ref src, str.AsSpan());
     }
 }

--- a/src/JustEat.StatsD/Buffered/StatsDMessage.cs
+++ b/src/JustEat.StatsD/Buffered/StatsDMessage.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace JustEat.StatsD.Buffered
 {
     internal readonly struct StatsDMessage
@@ -5,27 +7,42 @@ namespace JustEat.StatsD.Buffered
         public readonly string StatBucket;
         public readonly double Magnitude;
         public readonly StatsDMessageKind MessageKind;
+        public readonly Dictionary<string, string?>? Tags;
 
-        private StatsDMessage(string statBucket, double magnitude, StatsDMessageKind messageKind)
+        private StatsDMessage(
+            string statBucket,
+            double magnitude,
+            StatsDMessageKind messageKind,
+            Dictionary<string, string?>? tags)
         {
             StatBucket = statBucket;
             Magnitude = magnitude;
             MessageKind = messageKind;
+            Tags = tags;
         }
 
-        public static StatsDMessage Timing(long milliseconds, string statBucket)
+        public static StatsDMessage Timing(
+            long milliseconds,
+            string statBucket,
+            Dictionary<string, string?>? tags)
         {
-            return new StatsDMessage(statBucket, milliseconds, StatsDMessageKind.Timing);
+            return new StatsDMessage(statBucket, milliseconds, StatsDMessageKind.Timing, tags);
         }
 
-        public static StatsDMessage Counter(long magnitude, string statBucket)
+        public static StatsDMessage Counter(
+            long magnitude,
+            string statBucket,
+            Dictionary<string, string?>? tags)
         {
-            return new StatsDMessage(statBucket, magnitude, StatsDMessageKind.Counter);
+            return new StatsDMessage(statBucket, magnitude, StatsDMessageKind.Counter, tags);
         }
 
-        public static StatsDMessage Gauge(double magnitude, string statBucket)
+        public static StatsDMessage Gauge(
+            double magnitude,
+            string statBucket,
+            Dictionary<string, string?>? tags)
         {
-            return new StatsDMessage(statBucket, magnitude, StatsDMessageKind.Gauge);
+            return new StatsDMessage(statBucket, magnitude, StatsDMessageKind.Gauge, tags);
         }
     }
 }

--- a/src/JustEat.StatsD/Buffered/StatsDUtf8Formatter.cs
+++ b/src/JustEat.StatsD/Buffered/StatsDUtf8Formatter.cs
@@ -1,18 +1,22 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+using JustEat.StatsD.TagsFormatters;
 
 namespace JustEat.StatsD.Buffered
 {
     internal sealed class StatsDUtf8Formatter
     {
         private readonly byte[] _utf8Prefix;
+        private readonly IStatsDTagsFormatter _tagsFormatter;
 
-        public StatsDUtf8Formatter(string prefix)
+        public StatsDUtf8Formatter(string prefix, IStatsDTagsFormatter tagsFormatter)
         {
             _utf8Prefix = string.IsNullOrWhiteSpace(prefix) ?
                 Array.Empty<byte>() :
                 Encoding.UTF8.GetBytes(prefix + ".");
+            _tagsFormatter = tagsFormatter ?? new NoOpTagsFormatter();
         }
 
         public int GetMaxBufferSize(in StatsDMessage msg)
@@ -24,39 +28,42 @@ namespace JustEat.StatsD.Buffered
             const int MaxSamplingSuffixSize = 2;
 
             return _utf8Prefix.Length
-                    + Encoding.UTF8.GetByteCount(msg.StatBucket)
-                    + ColonBytes
-                    + MaxSerializedDoubleSymbols
-                    + MaxMessageKindSuffixSize
-                    + MaxSamplingSuffixSize
-                    + MaxSerializedDoubleSymbols;
+                   + Encoding.UTF8.GetByteCount(msg.StatBucket)
+                   + ColonBytes
+                   + MaxSerializedDoubleSymbols
+                   + MaxMessageKindSuffixSize
+                   + MaxSamplingSuffixSize
+                   + MaxSerializedDoubleSymbols
+                   + GetTagsBufferSize(msg.Tags);
         }
 
         public bool TryFormat(in StatsDMessage msg, double sampleRate, Span<byte> destination, out int written)
         {
-            var buffer = new Buffer(destination);
+            var buffer = new Buffer<byte>(destination);
 
             bool isFormattingSuccessful =
-                  TryWriteBucketNameWithColon(ref buffer, msg.StatBucket)
+                  TryWriteBucketNameWithColon(ref buffer, msg)
                && TryWritePayloadWithMessageKindSuffix(ref buffer, msg)
-               && TryWriteSampleRateIfNeeded(ref buffer, sampleRate);
+               && TryWriteSampleRateIfNeeded(ref buffer, sampleRate)
+               && TryWriteTrailingTagsIfNeeded(ref buffer, msg.Tags);
 
             written = isFormattingSuccessful ? buffer.Written : 0;
             return isFormattingSuccessful;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryWriteBucketNameWithColon(ref Buffer buffer, string statBucket)
+        private bool TryWriteBucketNameWithColon(ref Buffer<byte> buffer, in StatsDMessage msg)
         {
-            // prefix + msg.Bucket + ":"
+            // prefix + msg.Bucket + {optional msg.Tags} + ":"
 
-            return buffer.TryWriteBytes(_utf8Prefix)
-                && buffer.TryWriteUtf8String(statBucket)
-                && buffer.TryWriteByte((byte)':');
+            return buffer.TryWrite(_utf8Prefix)
+                && buffer.TryWriteUtf8String(msg.StatBucket)
+                && TryWriteBucketNameTagsIfNeeded(ref buffer, msg.Tags)
+                && buffer.TryWrite((byte)':');
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryWritePayloadWithMessageKindSuffix(ref Buffer buffer, in StatsDMessage msg)
+        private static bool TryWritePayloadWithMessageKindSuffix(ref Buffer<byte> buffer, in StatsDMessage msg)
         {
             // msg.Value + (<oneOf> "|ms", "|c", "|g")
 
@@ -67,12 +74,12 @@ namespace JustEat.StatsD.Buffered
                 case StatsDMessageKind.Counter:
                     {
                         return buffer.TryWriteInt64(integralMagnitude)
-                            && buffer.TryWriteBytes((byte)'|', (byte)'c');
+                            && buffer.TryWrite((byte)'|', (byte)'c');
                     }
                 case StatsDMessageKind.Timing:
                     {
                         return buffer.TryWriteInt64(integralMagnitude)
-                            && buffer.TryWriteBytes((byte)'|', (byte)'m', (byte)'s');
+                            && buffer.TryWrite((byte)'|', (byte)'m', (byte)'s');
                     }
                 case StatsDMessageKind.Gauge:
                     {
@@ -83,7 +90,7 @@ namespace JustEat.StatsD.Buffered
                             buffer.TryWriteInt64(integralMagnitude) :
                             buffer.TryWriteDouble(msg.Magnitude);
 
-                        return successSoFar && buffer.TryWriteBytes((byte)'|', (byte)'g');
+                        return successSoFar && buffer.TryWrite((byte)'|', (byte)'g');
                     }
                 default:
                     throw new ArgumentOutOfRangeException(nameof(msg));
@@ -91,17 +98,39 @@ namespace JustEat.StatsD.Buffered
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryWriteSampleRateIfNeeded(ref Buffer buffer, double sampleRate)
+        private static bool TryWriteSampleRateIfNeeded(ref Buffer<byte> buffer, double sampleRate)
         {
             // {<optional> "|@" + sampleRate}
 
             if (sampleRate < 1.0 && sampleRate > 0.0)
             {
-                return buffer.TryWriteBytes((byte)'|', (byte)'@')
+                return buffer.TryWrite((byte)'|', (byte)'@')
                     && buffer.TryWriteDouble(sampleRate);
             }
 
             return true;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int GetTagsBufferSize(in Dictionary<string, string?>? tags) =>
+            AreTagsPresent(tags)
+                ? _tagsFormatter.GetTagsBufferSize(tags!)
+                : 0;
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryWriteBucketNameTagsIfNeeded(ref Buffer<byte> buffer, in Dictionary<string, string?>? tags) =>
+            AreTagsPresent(tags) && !_tagsFormatter.AreTrailing
+                ? buffer.TryWriteUtf8Chars(_tagsFormatter.FormatTags(tags!))
+                : true;
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryWriteTrailingTagsIfNeeded(ref Buffer<byte> buffer, in Dictionary<string, string?>? tags) =>
+            AreTagsPresent(tags) && _tagsFormatter.AreTrailing
+                ? buffer.TryWriteUtf8Chars(_tagsFormatter.FormatTags(tags!))
+                : true;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AreTagsPresent(in Dictionary<string, string?>? tags) =>
+            tags != null && tags.Count > 0;
     }
 }

--- a/src/JustEat.StatsD/DisposableTimer.cs
+++ b/src/JustEat.StatsD/DisposableTimer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace JustEat.StatsD
@@ -12,7 +13,14 @@ namespace JustEat.StatsD
 
         public string Bucket { get; set; }
 
+        public Dictionary<string, string?>? Tags { get; set; }
+
         public DisposableTimer(IStatsDPublisher publisher, string bucket)
+            : this(publisher, bucket, null)
+        {
+        }
+
+        public DisposableTimer(IStatsDPublisher publisher, string bucket, Dictionary<string, string?>? tags)
         {
             _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
 
@@ -22,6 +30,7 @@ namespace JustEat.StatsD
             }
 
             Bucket = bucket;
+            Tags = tags;
             _stopwatch = Stopwatch.StartNew();
         }
 
@@ -37,7 +46,7 @@ namespace JustEat.StatsD
                     throw new InvalidOperationException($"The {nameof(Bucket)} property must have a value.");
                 }
 
-                _publisher.Timing(_stopwatch.Elapsed, Bucket);
+                _publisher.Timing(_stopwatch.Elapsed, Bucket, Tags);
             }
         }
     }

--- a/src/JustEat.StatsD/IStatsDPublisher.cs
+++ b/src/JustEat.StatsD/IStatsDPublisher.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace JustEat.StatsD
 {
     /// <summary>
@@ -11,14 +13,16 @@ namespace JustEat.StatsD
         /// <param name="value">The value to increment the counter by.</param>
         /// <param name="sampleRate">The sample rate for the counter.</param>
         /// <param name="bucket">The bucket to increment the counter for.</param>
-        void Increment(long value, double sampleRate, string bucket);
+        /// <param name="tags">The tag(s) to publish with the counter.</param>
+        void Increment(long value, double sampleRate, string bucket, Dictionary<string, string?>? tags);
 
         /// <summary>
         /// Publishes a gauge for the specified bucket and value.
         /// </summary>
         /// <param name="value">The value to publish for the gauge.</param>
         /// <param name="bucket">The bucket to publish the gauge for.</param>
-        void Gauge(double value, string bucket);
+        /// <param name="tags">The tag(s) to publish with the gauge.</param>
+        void Gauge(double value, string bucket, Dictionary<string, string?>? tags);
 
         /// <summary>
         /// Publishes a timer for the specified bucket and value.
@@ -26,6 +30,7 @@ namespace JustEat.StatsD
         /// <param name="duration">The value to publish for the timer.</param>
         /// <param name="sampleRate">The sample rate for the timer.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
-        void Timing(long duration, double sampleRate, string bucket);
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
+        void Timing(long duration, double sampleRate, string bucket, Dictionary<string, string?>? tags);
     }
 }

--- a/src/JustEat.StatsD/IStatsDPublisherExtensions.cs
+++ b/src/JustEat.StatsD/IStatsDPublisherExtensions.cs
@@ -13,13 +13,49 @@ namespace JustEat.StatsD
         private const double DefaultSampleRate = 1.0;
 
         /// <summary>
+        /// Publishes a counter for the specified bucket and value without tags.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="value">The value to increment the counter by.</param>
+        /// <param name="sampleRate">The sample rate for the counter.</param>
+        /// <param name="bucket">The bucket to increment the counter for.</param>
+        public static void Increment(this IStatsDPublisher publisher, long value, double sampleRate, string bucket)
+        {
+            publisher.Increment(value, sampleRate, bucket, null);
+        }
+
+        /// <summary>
+        /// Publishes a gauge for the specified bucket and value without tags.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="value">The value to publish for the gauge.</param>
+        /// <param name="bucket">The bucket to publish the gauge for.</param>
+        public static void Gauge(this IStatsDPublisher publisher, double value, string bucket)
+        {
+            publisher.Gauge(value, bucket, null);
+        }
+
+        /// <summary>
+        /// Publishes a timer for the specified bucket and value without tags.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="duration">The value to publish for the timer.</param>
+        /// <param name="sampleRate">The sample rate for the timer.</param>
+        /// <param name="bucket">The bucket to publish the timer for.</param>
+        public static void Timing(this IStatsDPublisher publisher, long duration, double sampleRate, string bucket)
+        {
+            publisher.Timing(duration, sampleRate, bucket, null);
+        }
+
+        /// <summary>
         /// Publishes a counter for the specified bucket with a value of one (1).
         /// </summary>
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to increment the counter for.</param>
-        public static void Increment(this IStatsDPublisher publisher, string bucket)
+        /// <param name="tags">The tag(s) to publish with the counter.</param>
+        public static void Increment(this IStatsDPublisher publisher, string bucket, Dictionary<string, string?>? tags = null)
         {
-            publisher.Increment(1, DefaultSampleRate, bucket);
+            publisher.Increment(1, DefaultSampleRate, bucket, tags);
         }
 
         /// <summary>
@@ -28,9 +64,14 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to increment the counter by.</param>
         /// <param name="bucket">The bucket to increment the counter for.</param>
-        public static void Increment(this IStatsDPublisher publisher, long value, string bucket)
+        /// <param name="tags">The tag(s) to publish with the counter.</param>
+        public static void Increment(
+            this IStatsDPublisher publisher,
+            long value,
+            string bucket,
+            Dictionary<string, string?>? tags = null)
         {
-            publisher.Increment(value, DefaultSampleRate, bucket);
+            publisher.Increment(value, DefaultSampleRate, bucket, tags);
         }
 
         /// <summary>
@@ -40,7 +81,12 @@ namespace JustEat.StatsD
         /// <param name="value">The value to increment the counter(s) by.</param>
         /// <param name="sampleRate">The sample rate for the counter(s).</param>
         /// <param name="buckets">The bucket(s) to increment the counter(s) for.</param>
-        public static void Increment(this IStatsDPublisher publisher, long value, double sampleRate, IEnumerable<string> buckets)
+        /// <param name="tags">The tag(s) to publish with the counter(s).</param>
+        public static void Increment(
+            this IStatsDPublisher publisher,
+            long value, double sampleRate,
+            IEnumerable<string> buckets,
+            Dictionary<string, string?>? tags = null)
         {
             if (buckets == null)
             {
@@ -49,7 +95,7 @@ namespace JustEat.StatsD
 
             foreach (string bucket in buckets)
             {
-                publisher.Increment(value, sampleRate, bucket);
+                publisher.Increment(value, sampleRate, bucket, tags);
             }
         }
 
@@ -62,6 +108,24 @@ namespace JustEat.StatsD
         /// <param name="buckets">The bucket(s) to increment the counter(s) for.</param>
         public static void Increment(this IStatsDPublisher publisher, long value, double sampleRate, params string[] buckets)
         {
+            publisher.Increment(value, sampleRate, tags: null, buckets);
+        }
+
+        /// <summary>
+        /// Publishes counter(s) for the specified bucket(s) and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="value">The value to increment the counter(s) by.</param>
+        /// <param name="sampleRate">The sample rate for the counter(s).</param>
+        /// <param name="tags">The tag(s) to publish with the counter.</param>
+        /// <param name="buckets">The bucket(s) to increment the counter(s) for.</param>
+        public static void Increment(
+            this IStatsDPublisher publisher,
+            long value,
+            double sampleRate,
+            Dictionary<string, string?>? tags,
+            params string[] buckets)
+        {
 #pragma warning disable CA1508
             if (buckets == null || buckets.Length == 0)
 #pragma warning restore CA1508
@@ -71,7 +135,7 @@ namespace JustEat.StatsD
 
             foreach (string bucket in buckets)
             {
-                publisher.Increment(value, sampleRate, bucket);
+                publisher.Increment(value, sampleRate, bucket, tags);
             }
         }
 
@@ -80,9 +144,10 @@ namespace JustEat.StatsD
         /// </summary>
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to decrement the counter for.</param>
-        public static void Decrement(this IStatsDPublisher publisher, string bucket)
+        /// <param name="tags">The tag(s) to publish with the counter.</param>
+        public static void Decrement(this IStatsDPublisher publisher, string bucket, Dictionary<string, string?>? tags = null)
         {
-            publisher.Increment(-1, DefaultSampleRate, bucket);
+            publisher.Increment(-1, DefaultSampleRate, bucket, tags);
         }
 
         /// <summary>
@@ -91,9 +156,14 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="value">The value to decrement the counter by.</param>
         /// <param name="bucket">The bucket to decrement the counter for.</param>
-        public static void Decrement(this IStatsDPublisher publisher, long value, string bucket)
+        /// <param name="tags">The tag(s) to publish with the counter.</param>
+        public static void Decrement(
+            this IStatsDPublisher publisher,
+            long value,
+            string bucket,
+            Dictionary<string, string?>? tags = null)
         {
-            publisher.Increment(value > 0 ? -value : value, DefaultSampleRate, bucket);
+            publisher.Increment(value > 0 ? -value : value, DefaultSampleRate, bucket, tags);
         }
 
         /// <summary>
@@ -103,9 +173,15 @@ namespace JustEat.StatsD
         /// <param name="value">The value to decrement the counter by.</param>
         /// <param name="sampleRate">The sample rate for the counter.</param>
         /// <param name="bucket">The bucket to decrement the counter for.</param>
-        public static void Decrement(this IStatsDPublisher publisher, long value, double sampleRate, string bucket)
+        /// <param name="tags">The tag(s) to publish with the counter.</param>
+        public static void Decrement(
+            this IStatsDPublisher publisher,
+            long value,
+            double sampleRate,
+            string bucket,
+            Dictionary<string, string?>? tags = null)
         {
-            publisher.Increment(value > 0 ? -value : value, sampleRate, bucket);
+            publisher.Increment(value > 0 ? -value : value, sampleRate, bucket, tags);
         }
 
         /// <summary>
@@ -115,7 +191,13 @@ namespace JustEat.StatsD
         /// <param name="value">The value to decrement the counter(s) by.</param>
         /// <param name="sampleRate">The sample rate for the counter(s).</param>
         /// <param name="buckets">The bucket(s) to decrement the counter(s) for.</param>
-        public static void Decrement(this IStatsDPublisher publisher, long value, double sampleRate, IEnumerable<string> buckets)
+        /// <param name="tags">The tag(s) to publish with the counter(s).</param>
+        public static void Decrement(
+            this IStatsDPublisher publisher,
+            long value,
+            double sampleRate,
+            IEnumerable<string> buckets,
+            Dictionary<string, string?>? tags = null)
         {
             if (buckets == null)
             {
@@ -126,7 +208,7 @@ namespace JustEat.StatsD
 
             foreach (string bucket in buckets)
             {
-                publisher.Increment(adjusted, sampleRate, bucket);
+                publisher.Increment(adjusted, sampleRate, bucket, tags);
             }
         }
 
@@ -139,6 +221,24 @@ namespace JustEat.StatsD
         /// <param name="buckets">The bucket(s) to decrement the counter(s) for.</param>
         public static void Decrement(this IStatsDPublisher publisher, long value, double sampleRate, params string[] buckets)
         {
+            publisher.Decrement(value, sampleRate, tags: null, buckets);
+        }
+
+        /// <summary>
+        /// Publishes counter decrement(s) for the specified bucket(s) and value.
+        /// </summary>
+        /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
+        /// <param name="value">The value to decrement the counter(s) by.</param>
+        /// <param name="sampleRate">The sample rate for the counter(s).</param>
+        /// <param name="tags">The tag(s) to publish with the counter(s).</param>
+        /// <param name="buckets">The bucket(s) to decrement the counter(s) for.</param>
+        public static void Decrement(
+            this IStatsDPublisher publisher,
+            long value,
+            double sampleRate,
+            Dictionary<string, string?>? tags,
+            params string[] buckets)
+        {
 #pragma warning disable CA1508
             if (buckets == null || buckets.Length == 0)
 #pragma warning restore CA1508
@@ -150,7 +250,7 @@ namespace JustEat.StatsD
 
             foreach (string bucket in buckets)
             {
-                publisher.Increment(adjusted, sampleRate, bucket);
+                publisher.Increment(adjusted, sampleRate, bucket, tags);
             }
         }
 
@@ -160,9 +260,14 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="duration">The value to publish for the timer.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
-        public static void Timing(this IStatsDPublisher publisher, TimeSpan duration, string bucket)
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
+        public static void Timing(
+            this IStatsDPublisher publisher,
+            TimeSpan duration,
+            string bucket,
+            Dictionary<string, string?>? tags = null)
         {
-            publisher.Timing((long)duration.TotalMilliseconds, DefaultSampleRate, bucket);
+            publisher.Timing((long)duration.TotalMilliseconds, DefaultSampleRate, bucket, tags);
         }
 
         /// <summary>
@@ -172,9 +277,15 @@ namespace JustEat.StatsD
         /// <param name="duration">The value to publish for the timer.</param>
         /// <param name="sampleRate">The sample rate for the timer.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
-        public static void Timing(this IStatsDPublisher publisher, TimeSpan duration, double sampleRate, string bucket)
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
+        public static void Timing(
+            this IStatsDPublisher publisher,
+            TimeSpan duration,
+            double sampleRate,
+            string bucket,
+            Dictionary<string, string?>? tags = null)
         {
-            publisher.Timing((long)duration.TotalMilliseconds, sampleRate, bucket);
+            publisher.Timing((long)duration.TotalMilliseconds, sampleRate, bucket, tags);
         }
 
         /// <summary>
@@ -183,9 +294,14 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="duration">The value to publish for the timer.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
-        public static void Timing(this IStatsDPublisher publisher, long duration, string bucket)
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
+        public static void Timing(
+            this IStatsDPublisher publisher,
+            long duration,
+            string bucket,
+            Dictionary<string, string?>? tags = null)
         {
-            publisher.Timing(duration, DefaultSampleRate, bucket);
+            publisher.Timing(duration, DefaultSampleRate, bucket, tags);
         }
     }
 }

--- a/src/JustEat.StatsD/PublicAPI.Shipped.txt
+++ b/src/JustEat.StatsD/PublicAPI.Shipped.txt
@@ -15,9 +15,9 @@ JustEat.StatsD.IDisposableTimer
 JustEat.StatsD.IDisposableTimer.Bucket.get -> string!
 JustEat.StatsD.IDisposableTimer.Bucket.set -> void
 JustEat.StatsD.IStatsDPublisher
-JustEat.StatsD.IStatsDPublisher.Gauge(double value, string! bucket) -> void
-JustEat.StatsD.IStatsDPublisher.Increment(long value, double sampleRate, string! bucket) -> void
-JustEat.StatsD.IStatsDPublisher.Timing(long duration, double sampleRate, string! bucket) -> void
+JustEat.StatsD.IStatsDPublisher.Gauge(double value, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags) -> void
+JustEat.StatsD.IStatsDPublisher.Increment(long value, double sampleRate, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags) -> void
+JustEat.StatsD.IStatsDPublisher.Timing(long duration, double sampleRate, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags) -> void
 JustEat.StatsD.IStatsDPublisherExtensions
 JustEat.StatsD.IStatsDTransport
 JustEat.StatsD.IStatsDTransport.Send(in System.ArraySegment<byte> metric) -> void
@@ -43,42 +43,85 @@ JustEat.StatsD.StatsDConfiguration.Prefix.set -> void
 JustEat.StatsD.StatsDConfiguration.SocketProtocol.get -> JustEat.StatsD.SocketProtocol
 JustEat.StatsD.StatsDConfiguration.SocketProtocol.set -> void
 JustEat.StatsD.StatsDConfiguration.StatsDConfiguration() -> void
+JustEat.StatsD.StatsDConfiguration.TagsFormatter.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
+JustEat.StatsD.StatsDConfiguration.TagsFormatter.set -> void
 JustEat.StatsD.StatsDPublisher
 JustEat.StatsD.StatsDPublisher.Dispose() -> void
-JustEat.StatsD.StatsDPublisher.Gauge(double value, string! bucket) -> void
-JustEat.StatsD.StatsDPublisher.Increment(long value, double sampleRate, string! bucket) -> void
+JustEat.StatsD.StatsDPublisher.Gauge(double value, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags) -> void
+JustEat.StatsD.StatsDPublisher.Increment(long value, double sampleRate, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags) -> void
 JustEat.StatsD.StatsDPublisher.StatsDPublisher(JustEat.StatsD.StatsDConfiguration! configuration) -> void
 JustEat.StatsD.StatsDPublisher.StatsDPublisher(JustEat.StatsD.StatsDConfiguration! configuration, JustEat.StatsD.IStatsDTransport! transport) -> void
-JustEat.StatsD.StatsDPublisher.Timing(long duration, double sampleRate, string! bucket) -> void
+JustEat.StatsD.StatsDPublisher.Timing(long duration, double sampleRate, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags) -> void
 JustEat.StatsD.StatsDServiceCollectionExtensions
+JustEat.StatsD.TagsFormatter
+JustEat.StatsD.TagsFormatters.InfluxDbTagsFormatter
+JustEat.StatsD.TagsFormatters.InfluxDbTagsFormatter.InfluxDbTagsFormatter() -> void
+JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter
+JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter.AreTrailing.get -> bool
+JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter.GetTagsBufferSize(in System.Collections.Generic.Dictionary<string!, string?>! tags) -> int
+JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter.FormatTags(in System.Collections.Generic.Dictionary<string!, string?>! tags) -> System.ReadOnlySpan<char>
+JustEat.StatsD.TagsFormatters.LibratoTagsFormatter
+JustEat.StatsD.TagsFormatters.LibratoTagsFormatter.LibratoTagsFormatter() -> void
+JustEat.StatsD.TagsFormatters.SignalFxTagsFormatter
+JustEat.StatsD.TagsFormatters.SignalFxTagsFormatter.SignalFxTagsFormatter() -> void
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatter
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatter.AreTrailing.get -> bool
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatter.StatsDTagsFormatter(JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration! configuration) -> void
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.StatsDTagsFormatterConfiguration() -> void
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.AreTrailing.get -> bool
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.AreTrailing.set -> void
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.KeyValueSeparator.get -> string!
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.KeyValueSeparator.set -> void
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.Prefix.get -> string!
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.Prefix.set -> void
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.Suffix.get -> string!
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.Suffix.set -> void
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.TagsSeparator.get -> string!
+JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.TagsSeparator.set -> void
+JustEat.StatsD.TagsFormatters.TrailingTagsFormatter
+JustEat.StatsD.TagsFormatters.TrailingTagsFormatter.TrailingTagsFormatter() -> void
 JustEat.StatsD.TimerExtensions
 const JustEat.StatsD.StatsDConfiguration.DefaultPort = 8125 -> int
 static JustEat.StatsD.EndpointLookups.EndPointFactory.MakeEndPointSource(System.Net.EndPoint! endpoint, System.TimeSpan? endpointCacheDuration) -> JustEat.StatsD.EndpointLookups.IEndPointSource!
 static JustEat.StatsD.EndpointLookups.EndPointFactory.MakeEndPointSource(string! host, int port, System.TimeSpan? endpointCacheDuration) -> JustEat.StatsD.EndpointLookups.IEndPointSource!
-static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, System.Collections.Generic.IEnumerable<string!>! buckets) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, System.Collections.Generic.IEnumerable<string!>! buckets, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
 static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, params string![]! buckets) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, string! bucket) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, long value, string! bucket) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, System.Collections.Generic.IEnumerable<string!>! buckets) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, System.Collections.Generic.Dictionary<string!, string?>? tags, params string![]! buckets) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, long value, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Decrement(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Gauge(this JustEat.StatsD.IStatsDPublisher! publisher, double value, string! bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, string! bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, System.Collections.Generic.IEnumerable<string!>! buckets, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
 static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, params string![]! buckets) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, long value, string! bucket) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher! publisher, System.TimeSpan duration, double sampleRate, string! bucket) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher! publisher, System.TimeSpan duration, string! bucket) -> void
-static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher! publisher, long duration, string! bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, long value, double sampleRate, System.Collections.Generic.Dictionary<string!, string?>? tags, params string![]! buckets) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, long value, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Increment(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher! publisher, long duration, double sampleRate, string! bucket) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher! publisher, System.TimeSpan duration, double sampleRate, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher! publisher, System.TimeSpan duration, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.IStatsDPublisherExtensions.Timing(this JustEat.StatsD.IStatsDPublisher! publisher, long duration, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
 static JustEat.StatsD.IStatsDTransportExtensions.Send(this JustEat.StatsD.IStatsDTransport! transport, System.Collections.Generic.IEnumerable<string!>! metrics) -> void
 static JustEat.StatsD.IStatsDTransportExtensions.Send(this JustEat.StatsD.IStatsDTransport! transport, string! metric) -> void
 static JustEat.StatsD.StatsDConfiguration.DefaultDnsLookupInterval.get -> System.TimeSpan
 static JustEat.StatsD.StatsDServiceCollectionExtensions.AddStatsD(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static JustEat.StatsD.StatsDServiceCollectionExtensions.AddStatsD(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Func<System.IServiceProvider!, JustEat.StatsD.StatsDConfiguration!>! configurationFactory) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 static JustEat.StatsD.StatsDServiceCollectionExtensions.AddStatsD(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! host, string? prefix = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static JustEat.StatsD.TimerExtensions.StartTimer(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket) -> JustEat.StatsD.IDisposableTimer!
-static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Action! action) -> void
-static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Action<JustEat.StatsD.IDisposableTimer!>! action) -> void
-static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<JustEat.StatsD.IDisposableTimer!, System.Threading.Tasks.Task!>! action) -> System.Threading.Tasks.Task!
-static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<System.Threading.Tasks.Task!>! action) -> System.Threading.Tasks.Task!
-static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<JustEat.StatsD.IDisposableTimer!, System.Threading.Tasks.Task<T>!>! func) -> System.Threading.Tasks.Task<T>!
-static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<JustEat.StatsD.IDisposableTimer!, T>! func) -> T
-static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<System.Threading.Tasks.Task<T>!>! func) -> System.Threading.Tasks.Task<T>!
-static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<T>! func) -> T
+static JustEat.StatsD.TagsFormatter.CloudWatch.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
+static JustEat.StatsD.TagsFormatter.DataDog.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
+static JustEat.StatsD.TagsFormatter.InfluxDb.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
+static JustEat.StatsD.TagsFormatter.Librato.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
+static JustEat.StatsD.TagsFormatter.SignalFx.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
+static JustEat.StatsD.TagsFormatter.Splunk.get -> JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter!
+static JustEat.StatsD.TimerExtensions.StartTimer(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> JustEat.StatsD.IDisposableTimer!
+static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Action! action, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Action<JustEat.StatsD.IDisposableTimer!>! action, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> void
+static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<JustEat.StatsD.IDisposableTimer!, System.Threading.Tasks.Task!>! action, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> System.Threading.Tasks.Task!
+static JustEat.StatsD.TimerExtensions.Time(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<System.Threading.Tasks.Task!>! action, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> System.Threading.Tasks.Task!
+static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<JustEat.StatsD.IDisposableTimer!, System.Threading.Tasks.Task<T>!>! func, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> System.Threading.Tasks.Task<T>!
+static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<JustEat.StatsD.IDisposableTimer!, T>! func, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> T
+static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<System.Threading.Tasks.Task<T>!>! func, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> System.Threading.Tasks.Task<T>!
+static JustEat.StatsD.TimerExtensions.Time<T>(this JustEat.StatsD.IStatsDPublisher! publisher, string! bucket, System.Func<T>! func, System.Collections.Generic.Dictionary<string!, string?>? tags = null) -> T
+virtual JustEat.StatsD.TagsFormatters.StatsDTagsFormatter.GetTagsBufferSize(in System.Collections.Generic.Dictionary<string!, string?>! tags) -> int
+virtual JustEat.StatsD.TagsFormatters.StatsDTagsFormatter.FormatTags(in System.Collections.Generic.Dictionary<string!, string?>! tags) -> System.ReadOnlySpan<char>

--- a/src/JustEat.StatsD/PublicAPI.Shipped.txt
+++ b/src/JustEat.StatsD/PublicAPI.Shipped.txt
@@ -54,18 +54,12 @@ JustEat.StatsD.StatsDPublisher.StatsDPublisher(JustEat.StatsD.StatsDConfiguratio
 JustEat.StatsD.StatsDPublisher.Timing(long duration, double sampleRate, string! bucket, System.Collections.Generic.Dictionary<string!, string?>? tags) -> void
 JustEat.StatsD.StatsDServiceCollectionExtensions
 JustEat.StatsD.TagsFormatter
-JustEat.StatsD.TagsFormatters.InfluxDbTagsFormatter
-JustEat.StatsD.TagsFormatters.InfluxDbTagsFormatter.InfluxDbTagsFormatter() -> void
 JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter
 JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter.AreTrailing.get -> bool
 JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter.GetTagsBufferSize(in System.Collections.Generic.Dictionary<string!, string?>! tags) -> int
 JustEat.StatsD.TagsFormatters.IStatsDTagsFormatter.FormatTags(in System.Collections.Generic.Dictionary<string!, string?>! tags) -> System.ReadOnlySpan<char>
-JustEat.StatsD.TagsFormatters.LibratoTagsFormatter
-JustEat.StatsD.TagsFormatters.LibratoTagsFormatter.LibratoTagsFormatter() -> void
-JustEat.StatsD.TagsFormatters.SignalFxTagsFormatter
-JustEat.StatsD.TagsFormatters.SignalFxTagsFormatter.SignalFxTagsFormatter() -> void
 JustEat.StatsD.TagsFormatters.StatsDTagsFormatter
-JustEat.StatsD.TagsFormatters.StatsDTagsFormatter.AreTrailing.get -> bool
+virtual JustEat.StatsD.TagsFormatters.StatsDTagsFormatter.AreTrailing.get -> bool
 JustEat.StatsD.TagsFormatters.StatsDTagsFormatter.StatsDTagsFormatter(JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration! configuration) -> void
 JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration
 JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.StatsDTagsFormatterConfiguration() -> void
@@ -79,8 +73,6 @@ JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.Suffix.get -> str
 JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.Suffix.set -> void
 JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.TagsSeparator.get -> string!
 JustEat.StatsD.TagsFormatters.StatsDTagsFormatterConfiguration.TagsSeparator.set -> void
-JustEat.StatsD.TagsFormatters.TrailingTagsFormatter
-JustEat.StatsD.TagsFormatters.TrailingTagsFormatter.TrailingTagsFormatter() -> void
 JustEat.StatsD.TimerExtensions
 const JustEat.StatsD.StatsDConfiguration.DefaultPort = 8125 -> int
 static JustEat.StatsD.EndpointLookups.EndPointFactory.MakeEndPointSource(System.Net.EndPoint! endpoint, System.TimeSpan? endpointCacheDuration) -> JustEat.StatsD.EndpointLookups.IEndPointSource!

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using JustEat.StatsD.TagsFormatters;
 
 namespace JustEat.StatsD
 {
@@ -50,6 +51,11 @@ namespace JustEat.StatsD
         /// Gets or sets an optional prefix to use for all stats.
         /// </summary>
         public string Prefix { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the formatter for tags. By default an instance of <see cref="NoOpTagsFormatter"/> is used.
+        /// </summary>
+        public IStatsDTagsFormatter TagsFormatter { get; set; } = new NoOpTagsFormatter();
 
         /// <summary>
         /// Gets or sets an optional delegate to invoke when an error occurs

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using JustEat.StatsD.Buffered;
 using JustEat.StatsD.EndpointLookups;
 
@@ -82,21 +83,21 @@ namespace JustEat.StatsD
         }
 
         /// <inheritdoc />
-        public void Increment(long value, double sampleRate, string bucket)
+        public void Increment(long value, double sampleRate, string bucket, Dictionary<string, string?>? tags)
         {
-            _inner.Increment(value, sampleRate, bucket);
+            _inner.Increment(value, sampleRate, bucket, tags);
         }
 
         /// <inheritdoc />
-        public void Gauge(double value, string bucket)
+        public void Gauge(double value, string bucket, Dictionary<string, string?>? tags)
         {
-            _inner.Gauge(value, bucket);
+            _inner.Gauge(value, bucket, tags);
         }
 
         /// <inheritdoc />
-        public void Timing(long duration, double sampleRate, string bucket)
+        public void Timing(long duration, double sampleRate, string bucket, Dictionary<string, string?>? tags)
         {
-            _inner.Timing(duration, sampleRate, bucket);
+            _inner.Timing(duration, sampleRate, bucket, tags);
         }
 
         /// <inheritdoc />

--- a/src/JustEat.StatsD/TagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatter.cs
@@ -1,0 +1,40 @@
+using JustEat.StatsD.TagsFormatters;
+
+namespace JustEat.StatsD
+{
+    /// <summary>
+    /// A class that can be used to retrieve supported <see cref="IStatsDTagsFormatter"/> implementations for some of the major metric providers.
+    /// </summary>
+    public static class TagsFormatter
+    {
+        /// <summary>
+        /// Gets an AWS CloudWatch tags formatter.
+        /// </summary>
+        public static IStatsDTagsFormatter CloudWatch => new TrailingTagsFormatter();
+
+        /// <summary>
+        /// Gets a DataDog tags formatter.
+        /// </summary>
+        public static IStatsDTagsFormatter DataDog => new TrailingTagsFormatter();
+        
+        /// <summary>
+        /// Gets an InfluxDB tags formatter.
+        /// </summary>
+        public static IStatsDTagsFormatter InfluxDb => new InfluxDbTagsFormatter();
+        
+        /// <summary>
+        /// Gets a Librato tags formatter.
+        /// </summary>
+        public static IStatsDTagsFormatter Librato => new LibratoTagsFormatter();
+        
+        /// <summary>
+        /// Gets a SignalFX dimensions formatter.
+        /// </summary>
+        public static IStatsDTagsFormatter SignalFx => new SignalFxTagsFormatter();
+        
+        /// <summary>
+        /// Gets a Splunk tags formatter.
+        /// </summary>
+        public static IStatsDTagsFormatter Splunk => new TrailingTagsFormatter();
+    }
+}

--- a/src/JustEat.StatsD/TagsFormatters/IStatsDTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/IStatsDTagsFormatter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace JustEat.StatsD.TagsFormatters
+{
+    /// <summary>
+    /// Defines an interface for formatting tags for extended StatsD specification.
+    /// </summary>
+    public interface IStatsDTagsFormatter
+    {
+        /// <summary>
+        /// Gets a value indicating whether the tags are at the end of the message or otherwise, they are placed with the bucket name.
+        /// </summary>
+        bool AreTrailing { get; }
+
+        /// <summary>
+        /// Calculates the buffer size to write tags considering the fixed characters and the size of the tag(s).
+        /// </summary>
+        /// <param name="tags">The tag(s) included.</param>
+        /// <returns>The amount of bytes dedicated in the buffer for the tags.</returns>
+        int GetTagsBufferSize(in Dictionary<string, string?> tags);
+
+        /// <summary>
+        /// Calculates the tag(s) formatted to be included in the StatsD message.
+        /// </summary>
+        /// <param name="tags">The tag(s) included.</param>
+        /// <returns>The tag(s) formatted.</returns>
+        ReadOnlySpan<char> FormatTags(in Dictionary<string, string?> tags);
+    }
+}

--- a/src/JustEat.StatsD/TagsFormatters/InfluxDbTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/InfluxDbTagsFormatter.cs
@@ -1,0 +1,29 @@
+namespace JustEat.StatsD.TagsFormatters
+{
+    /// <summary>
+    /// Formats StatsD tags for InfluxDB.
+    /// Tags placed right after the bucket name with format: <code>"," + tag1=value1,tag2,tag3=value</code>.
+    /// </summary>
+    public sealed class InfluxDbTagsFormatter : StatsDTagsFormatter
+    {
+        private const string Prefix = ",";
+        private const bool AreTrailingTags = false;
+        private const string TagsSeparator = ",";
+        private const string KeyValueSeparator = "=";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InfluxDbTagsFormatter"/> class.
+        /// </summary>
+        public InfluxDbTagsFormatter()
+            : base(new StatsDTagsFormatterConfiguration
+                {
+                    Prefix = Prefix,
+                    Suffix = string.Empty,
+                    AreTrailing = AreTrailingTags,
+                    TagsSeparator = TagsSeparator,
+                    KeyValueSeparator = KeyValueSeparator,
+                })
+        {
+        }
+    }
+}

--- a/src/JustEat.StatsD/TagsFormatters/InfluxDbTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/InfluxDbTagsFormatter.cs
@@ -4,7 +4,7 @@ namespace JustEat.StatsD.TagsFormatters
     /// Formats StatsD tags for InfluxDB.
     /// Tags placed right after the bucket name with format: <code>"," + tag1=value1,tag2,tag3=value</code>.
     /// </summary>
-    public sealed class InfluxDbTagsFormatter : StatsDTagsFormatter
+    internal sealed class InfluxDbTagsFormatter : StatsDTagsFormatter
     {
         private const string Prefix = ",";
         private const bool AreTrailingTags = false;

--- a/src/JustEat.StatsD/TagsFormatters/LibratoTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/LibratoTagsFormatter.cs
@@ -1,0 +1,29 @@
+namespace JustEat.StatsD.TagsFormatters
+{
+    /// <summary>
+    /// Formats StatsD tags for Librato.
+    /// Tags placed right after the bucket name with format: <code>"#" + tag1=value1,tag2,tag3=value</code>.
+    /// </summary>
+    public sealed class LibratoTagsFormatter : StatsDTagsFormatter
+    {
+        private const string Prefix = "#";
+        private const bool AreTrailingTags = false;
+        private const string TagsSeparator = ",";
+        private const string KeyValueSeparator = "=";
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibratoTagsFormatter"/> class.
+        /// </summary>
+        public LibratoTagsFormatter()
+            : base(new StatsDTagsFormatterConfiguration
+                {
+                    Prefix = Prefix,
+                    Suffix = string.Empty,
+                    AreTrailing = AreTrailingTags,
+                    TagsSeparator = TagsSeparator,
+                    KeyValueSeparator = KeyValueSeparator,
+                })
+        {
+        }
+    }
+}

--- a/src/JustEat.StatsD/TagsFormatters/LibratoTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/LibratoTagsFormatter.cs
@@ -4,7 +4,7 @@ namespace JustEat.StatsD.TagsFormatters
     /// Formats StatsD tags for Librato.
     /// Tags placed right after the bucket name with format: <code>"#" + tag1=value1,tag2,tag3=value</code>.
     /// </summary>
-    public sealed class LibratoTagsFormatter : StatsDTagsFormatter
+    internal sealed class LibratoTagsFormatter : StatsDTagsFormatter
     {
         private const string Prefix = "#";
         private const bool AreTrailingTags = false;

--- a/src/JustEat.StatsD/TagsFormatters/NoOpTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/NoOpTagsFormatter.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace JustEat.StatsD.TagsFormatters
+{
+    internal sealed class NoOpTagsFormatter : IStatsDTagsFormatter
+    {
+        public bool AreTrailing { get; }
+
+        public int GetTagsBufferSize(in Dictionary<string, string?> tags) => 0;
+        
+        public ReadOnlySpan<char> FormatTags(in Dictionary<string, string?> tags) => ReadOnlySpan<char>.Empty;
+    }
+}

--- a/src/JustEat.StatsD/TagsFormatters/NoOpTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/NoOpTagsFormatter.cs
@@ -5,7 +5,7 @@ namespace JustEat.StatsD.TagsFormatters
 {
     internal sealed class NoOpTagsFormatter : IStatsDTagsFormatter
     {
-        public bool AreTrailing { get; }
+        public bool AreTrailing => false;
 
         public int GetTagsBufferSize(in Dictionary<string, string?> tags) => 0;
         

--- a/src/JustEat.StatsD/TagsFormatters/SignalFxTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/SignalFxTagsFormatter.cs
@@ -1,0 +1,30 @@
+namespace JustEat.StatsD.TagsFormatters
+{
+    /// <summary>
+    /// Formats StatsD tags for SignalFX.
+    /// Tags placed right after the bucket name with format: <code>"[" + tag1=value1,tag2,tag3=value + "]"</code>.
+    /// </summary>
+    public sealed class SignalFxTagsFormatter : StatsDTagsFormatter
+    {
+        private const string Prefix = "[";
+        private const string Suffix = "]";
+        private const bool AreTrailingTags = false;
+        private const string TagsSeparator = ",";
+        private const string KeyValueSeparator = "=";
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SignalFxTagsFormatter"/> class.
+        /// </summary>
+        public SignalFxTagsFormatter()
+            : base(new StatsDTagsFormatterConfiguration
+                {
+                    Prefix = Prefix,
+                    Suffix = Suffix,
+                    AreTrailing = AreTrailingTags,
+                    TagsSeparator = TagsSeparator,
+                    KeyValueSeparator = KeyValueSeparator,
+                })
+        {
+        }
+    }
+}

--- a/src/JustEat.StatsD/TagsFormatters/SignalFxTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/SignalFxTagsFormatter.cs
@@ -4,7 +4,7 @@ namespace JustEat.StatsD.TagsFormatters
     /// Formats StatsD tags for SignalFX.
     /// Tags placed right after the bucket name with format: <code>"[" + tag1=value1,tag2,tag3=value + "]"</code>.
     /// </summary>
-    public sealed class SignalFxTagsFormatter : StatsDTagsFormatter
+    internal sealed class SignalFxTagsFormatter : StatsDTagsFormatter
     {
         private const string Prefix = "[";
         private const string Suffix = "]";

--- a/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatter.cs
@@ -31,6 +31,7 @@ namespace JustEat.StatsD.TagsFormatters
         /// Initializes a new instance of the <see cref="StatsDTagsFormatter"/> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
+        /// <exception cref="ArgumentNullException"> Thrown when the configuration is null.</exception>
         protected StatsDTagsFormatter(StatsDTagsFormatterConfiguration configuration)
         {
             if (configuration == null)
@@ -50,7 +51,7 @@ namespace JustEat.StatsD.TagsFormatters
         }
         
         /// <inheritdoc />
-        public bool AreTrailing { get; }
+        public virtual bool AreTrailing { get; }
 
         /// <inheritdoc />
         public virtual int GetTagsBufferSize(in Dictionary<string, string?> tags)

--- a/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatter.cs
@@ -31,7 +31,7 @@ namespace JustEat.StatsD.TagsFormatters
         /// Initializes a new instance of the <see cref="StatsDTagsFormatter"/> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
-        /// <exception cref="ArgumentNullException"> Thrown when the configuration is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="configuration"/> is <see langword="null"/>.</exception>
         protected StatsDTagsFormatter(StatsDTagsFormatterConfiguration configuration)
         {
             if (configuration == null)

--- a/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatter.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using JustEat.StatsD.Buffered;
+
+namespace JustEat.StatsD.TagsFormatters
+{
+    /// <summary>
+    /// A template class to format StatsD tags with configured values.
+    /// </summary>
+    public abstract class StatsDTagsFormatter : IStatsDTagsFormatter
+    {
+        private const int SafeUdpPacketSize = 512;
+
+        [ThreadStatic]
+        private static char[]? _buffer;
+        private static char[] Buffer => _buffer ??= new char[SafeUdpPacketSize];
+
+        private readonly char[] _prefix;
+        private readonly char[] _suffix;
+        private readonly char[] _tagsSeparator;
+        private readonly char[] _keyValueSeparator;
+        private readonly int _prefixSize;
+        private readonly int _suffixSize;
+        private readonly int _tagsSeparatorSize;
+        private readonly int _keyValueSeparatorSize;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatsDTagsFormatter"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        protected StatsDTagsFormatter(StatsDTagsFormatterConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            _prefix = configuration.Prefix?.ToArray() ?? Array.Empty<char>();
+            _suffix = configuration.Suffix?.ToArray() ?? Array.Empty<char>();
+            AreTrailing = configuration.AreTrailing;
+            _tagsSeparator = configuration.TagsSeparator?.ToArray() ?? Array.Empty<char>();
+            _keyValueSeparator = configuration.KeyValueSeparator?.ToArray() ?? Array.Empty<char>();
+            _prefixSize = Encoding.UTF8.GetByteCount(_prefix);
+            _suffixSize = Encoding.UTF8.GetByteCount(_suffix);
+            _tagsSeparatorSize = Encoding.UTF8.GetByteCount(_tagsSeparator);
+            _keyValueSeparatorSize = Encoding.UTF8.GetByteCount(_keyValueSeparator);
+        }
+        
+        /// <inheritdoc />
+        public bool AreTrailing { get; }
+
+        /// <inheritdoc />
+        public virtual int GetTagsBufferSize(in Dictionary<string, string?> tags)
+        {
+            const int NoTagsSize = 0;
+            if (!AreTagsPresent(tags))
+            {
+                return NoTagsSize;
+            }
+
+            return _prefixSize
+                + GetTagsSize(tags)
+                + _suffixSize;
+        }
+        
+        /// <inheritdoc />
+        public virtual ReadOnlySpan<char> FormatTags(in Dictionary<string, string?> tags)
+        {
+            if (!AreTagsPresent(tags))
+            {
+                return ReadOnlySpan<char>.Empty;
+            }
+
+            char[] destination = Buffer;
+            if (!TryFormatTags(destination, tags, out int written))
+            {
+                var newSize = GetTagsBufferSize(tags);
+                _buffer = new char[newSize];
+                destination = Buffer;
+
+                if (!TryFormatTags(destination, tags, out written))
+                {
+                    throw new FormatException("Failed to format tags.");
+                }
+            }
+
+            return new ArraySegment<char>(destination, 0, written);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryFormatTags(Span<char> destination, in Dictionary<string, string?> tags, out int written)
+        {
+            var buffer = new Buffer<char>(destination);
+            bool isFormattingSuccessful = buffer.TryWrite(_prefix)
+                && TryWriteTags(ref buffer, tags)
+                && buffer.TryWrite(_suffix);
+
+            written = isFormattingSuccessful ? buffer.Written : 0;
+
+            return isFormattingSuccessful;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryWriteTags(ref Buffer<char> buffer, in Dictionary<string, string?> tags)
+        {
+            var index = 0;
+            foreach (var tag in tags)
+            {
+                var isFormattingSuccessful = TryWriteTag(ref buffer, tag)
+                                             && TryWriteTagsSeparator(ref buffer, index++, tags);
+                if (!isFormattingSuccessful)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryWriteTagsSeparator(ref Buffer<char> buffer, int index, in Dictionary<string, string?> tags) =>
+            !IsLastTag(index, tags)
+                ? buffer.TryWrite(_tagsSeparator)
+                : true;
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsLastTag(int index, in Dictionary<string, string?> tags) =>
+            index == tags.Count - 1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryWriteTag(ref Buffer<char> buffer, in KeyValuePair<string, string?> tag) =>
+            buffer.TryWriteString(tag.Key)
+            && TryWriteTagValueIfNeeded(ref buffer, tag);
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool TryWriteTagValueIfNeeded(ref Buffer<char> buffer, KeyValuePair<string, string?> tag) =>
+            tag.Value != null
+                ? buffer.TryWrite(_keyValueSeparator) && buffer.TryWriteString(tag.Value!)
+                : true;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool AreTagsPresent(in Dictionary<string, string?>? tags) =>
+            tags != null && tags.Count > 0;
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int GetTagsSize(in Dictionary<string, string?> tags)
+        {
+            var tagsSize = 0;
+            foreach (KeyValuePair<string, string?> tag in tags)
+            {
+                tagsSize += GetTagSize(tag);
+            }
+
+            tagsSize += (tags.Count - 1) * _tagsSeparatorSize;
+
+            return tagsSize;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int GetTagSize(KeyValuePair<string, string?> tag) =>
+            Encoding.UTF8.GetByteCount(tag.Key) + GetTagValueSize(tag);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int GetTagValueSize(KeyValuePair<string, string?> tag) =>
+            tag.Value != null
+                ? Encoding.UTF8.GetByteCount(tag.Value) + _keyValueSeparatorSize
+                : 0;
+    }
+}

--- a/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatterConfiguration.cs
+++ b/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatterConfiguration.cs
@@ -1,0 +1,33 @@
+namespace JustEat.StatsD.TagsFormatters
+{
+    /// <summary>
+    /// A class representing the configuration options for <see cref="StatsDTagsFormatter"/>.
+    /// </summary>
+    public class StatsDTagsFormatterConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the character(s) before the tag(s).
+        /// </summary>
+        public string Prefix { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the character(s) after the tag(s).
+        /// </summary>
+        public string Suffix { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets a value indicating if the tags at the end of the message or otherwise, if tags are placed along with the bucket name.
+        /// </summary>
+        public bool AreTrailing { get; set; }
+
+        /// <summary>
+        /// Gets or sets the character(s) between tags.
+        /// </summary>
+        public string TagsSeparator { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the character(s) between the tag key and its value.
+        /// </summary>
+        public string KeyValueSeparator { get; set; } = string.Empty;
+    }
+}

--- a/src/JustEat.StatsD/TagsFormatters/TrailingTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/TrailingTagsFormatter.cs
@@ -4,7 +4,7 @@ namespace JustEat.StatsD.TagsFormatters
     /// Formats StatsD tags placed at the end of the message. Supported by DataDog, Splunk and AWS CloudWatch.
     /// Tags placed at the end of the message with format: <code>"|#" + tag1:value1,tag2,tag3:value</code>.
     /// </summary>
-    public sealed class TrailingTagsFormatter : StatsDTagsFormatter
+    internal sealed class TrailingTagsFormatter : StatsDTagsFormatter
     {
         private const string Prefix = "|#";
         private const bool AreTrailingTags = true;

--- a/src/JustEat.StatsD/TagsFormatters/TrailingTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/TrailingTagsFormatter.cs
@@ -1,0 +1,29 @@
+namespace JustEat.StatsD.TagsFormatters
+{
+    /// <summary>
+    /// Formats StatsD tags placed at the end of the message. Supported by DataDog, Splunk and AWS CloudWatch.
+    /// Tags placed at the end of the message with format: <code>"|#" + tag1:value1,tag2,tag3:value</code>.
+    /// </summary>
+    public sealed class TrailingTagsFormatter : StatsDTagsFormatter
+    {
+        private const string Prefix = "|#";
+        private const bool AreTrailingTags = true;
+        private const string TagsSeparator = ",";
+        private const string KeyValueSeparator = ":";
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrailingTagsFormatter"/> class.
+        /// </summary>
+        public TrailingTagsFormatter()
+            : base(new StatsDTagsFormatterConfiguration
+                {
+                    Prefix = Prefix,
+                    Suffix = string.Empty,
+                    AreTrailing = AreTrailingTags,
+                    TagsSeparator = TagsSeparator,
+                    KeyValueSeparator = KeyValueSeparator,
+                })
+        {
+        }
+    }
+}

--- a/src/JustEat.StatsD/TimerExtensions.cs
+++ b/src/JustEat.StatsD/TimerExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
@@ -15,15 +16,19 @@ namespace JustEat.StatsD
         /// </summary>
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <returns>
         /// An <see cref="IDisposableTimer"/> that publishes the metric when the instance is disposed of.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/> or <paramref name="bucket"/> is <see langword="null"/>.
         /// </exception>
-        public static IDisposableTimer StartTimer(this IStatsDPublisher publisher, string bucket)
+        public static IDisposableTimer StartTimer(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Dictionary<string, string?>? tags = null)
         {
-            return new DisposableTimer(publisher, bucket);
+            return new DisposableTimer(publisher, bucket, tags);
         }
 
         /// <summary>
@@ -33,17 +38,22 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         /// <param name="action">A delegate to a method whose invocation should be timed.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/>, <paramref name="bucket"/> or <paramref name="action"/> is <see langword="null"/>.
         /// </exception>
-        public static void Time(this IStatsDPublisher publisher, string bucket, Action action)
+        public static void Time(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Action action,
+            Dictionary<string, string?>? tags = null)
         {
             if (action == null)
             {
                 throw new ArgumentNullException(nameof(action));
             }
 
-            using (StartTimer(publisher, bucket))
+            using (StartTimer(publisher, bucket, tags))
             {
                 action();
             }
@@ -56,17 +66,22 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         /// <param name="action">A delegate to a method whose invocation should be timed.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/>, <paramref name="bucket"/> or <paramref name="action"/> is <see langword="null"/>.
         /// </exception>
-        public static void Time(this IStatsDPublisher publisher, string bucket, Action<IDisposableTimer> action)
+        public static void Time(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Action<IDisposableTimer> action,
+            Dictionary<string, string?>? tags = null)
         {
             if (action == null)
             {
                 throw new ArgumentNullException(nameof(action));
             }
 
-            using (var timer = StartTimer(publisher, bucket))
+            using (var timer = StartTimer(publisher, bucket, tags))
             {
                 action(timer);
             }
@@ -79,25 +94,29 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         /// <param name="action">A delegate to a method whose invocation should be timed.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation to time.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/>, <paramref name="bucket"/> or <paramref name="action"/> is <see langword="null"/>.
         /// </exception>
-        public static async Task Time(this IStatsDPublisher publisher, string bucket, Func<Task> action)
+        public static async Task Time(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Func<Task> action,
+            Dictionary<string, string?>? tags = null)
         {
             if (action == null)
             {
                 throw new ArgumentNullException(nameof(action));
             }
 
-            using (StartTimer(publisher, bucket))
+            using (StartTimer(publisher, bucket, tags))
             {
                 await action().ConfigureAwait(false);
             }
         }
-
 
         /// <summary>
         /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
@@ -106,47 +125,57 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         /// <param name="action">A delegate to a method whose invocation should be timed.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation to time.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/>, <paramref name="bucket"/> or <paramref name="action"/> is <see langword="null"/>.
         /// </exception>
-        public static async Task Time(this IStatsDPublisher publisher, string bucket, Func<IDisposableTimer, Task> action)
+        public static async Task Time(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Func<IDisposableTimer, Task> action,
+            Dictionary<string, string?>? tags = null)
         {
             if (action == null)
             {
                 throw new ArgumentNullException(nameof(action));
             }
 
-            using (var timer = StartTimer(publisher, bucket))
+            using (var timer = StartTimer(publisher, bucket, tags))
             {
                 await action(timer).ConfigureAwait(false);
             }
         }
 
         /// <summary>
-        /// Starts a new timer for the specified bucket which is started when the specified delegate is invoked
+        /// Starts a new timer for the specified bucket and any tag(s) which is started when the specified delegate is invoked
         /// and is stopped and published when the delegate invocation completes.
         /// </summary>
         /// <typeparam name="T">The type of the result of the delegate to invoke.</typeparam>
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         /// <param name="func">A delegate to a method whose invocation should be timed and result returned.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <returns>
         /// The value from invoking <paramref name="func"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/>, <paramref name="bucket"/> or <paramref name="func"/> is <see langword="null"/>.
         /// </exception>
-        public static T Time<T>(this IStatsDPublisher publisher, string bucket, Func<T> func)
+        public static T Time<T>(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Func<T> func,
+            Dictionary<string, string?>? tags = null)
         {
             if (func == null)
             {
                 throw new ArgumentNullException(nameof(func));
             }
 
-            using (StartTimer(publisher, bucket))
+            using (StartTimer(publisher, bucket, tags))
             {
                 return func();
             }
@@ -160,20 +189,25 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         /// <param name="func">A delegate to a method whose invocation should be timed and result returned.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <returns>
         /// The value from invoking <paramref name="func"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/>, <paramref name="bucket"/> or <paramref name="func"/> is <see langword="null"/>.
         /// </exception>
-        public static T Time<T>(this IStatsDPublisher publisher, string bucket, Func<IDisposableTimer, T> func)
+        public static T Time<T>(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Func<IDisposableTimer, T> func,
+            Dictionary<string, string?>? tags = null)
         {
             if (func == null)
             {
                 throw new ArgumentNullException(nameof(func));
             }
 
-            using (var timer = StartTimer(publisher, bucket))
+            using (var timer = StartTimer(publisher, bucket, tags))
             {
                 return func(timer);
             }
@@ -187,20 +221,25 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         /// <param name="func">A delegate to a method whose invocation should be timed and result returned.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation to time.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/>, <paramref name="bucket"/> or <paramref name="func"/> is <see langword="null"/>.
         /// </exception>
-        public static async Task<T> Time<T>(this IStatsDPublisher publisher, string bucket, Func<Task<T>> func)
+        public static async Task<T> Time<T>(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Func<Task<T>> func,
+            Dictionary<string, string?>? tags = null)
         {
             if (func == null)
             {
                 throw new ArgumentNullException(nameof(func));
             }
 
-            using (StartTimer(publisher, bucket))
+            using (StartTimer(publisher, bucket, tags))
             {
                 return await func().ConfigureAwait(false);
             }
@@ -214,20 +253,25 @@ namespace JustEat.StatsD
         /// <param name="publisher">The <see cref="IStatsDPublisher"/> to publish with.</param>
         /// <param name="bucket">The bucket to publish the timer for.</param>
         /// <param name="func">A delegate to a method whose invocation should be timed and result returned.</param>
+        /// <param name="tags">The tag(s) to publish with the timer.</param>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous operation to time.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// <paramref name="publisher"/>, <paramref name="bucket"/> or <paramref name="func"/> is <see langword="null"/>.
         /// </exception>
-        public static async Task<T> Time<T>(this IStatsDPublisher publisher, string bucket, Func<IDisposableTimer, Task<T>> func)
+        public static async Task<T> Time<T>(
+            this IStatsDPublisher publisher,
+            string bucket,
+            Func<IDisposableTimer, Task<T>> func,
+            Dictionary<string, string?>? tags = null)
         {
             if (func == null)
             {
                 throw new ArgumentNullException(nameof(func));
             }
 
-            using (var timer = StartTimer(publisher, bucket))
+            using (var timer = StartTimer(publisher, bucket, tags))
             {
                 return await func(timer).ConfigureAwait(false);
             }

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1001;CA1822</NoWarn>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <!-- Workaround for https://github.com/dotnet/BenchmarkDotNet/pull/1420 -->
+    <LangVersion>9.0</LangVersion>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CA1001;CA1822</NoWarn>
+    <NoWarn>$(NoWarn);CA1001;CA1014;CA1822</NoWarn>
     <OutputType>Exe</OutputType>
     <!-- Workaround for https://github.com/dotnet/BenchmarkDotNet/pull/1420 -->
     <LangVersion>9.0</LangVersion>

--- a/tests/Benchmark/StatSendingBenchmark.cs
+++ b/tests/Benchmark/StatSendingBenchmark.cs
@@ -73,14 +73,14 @@ namespace Benchmark
             _ipSender!.Increment(20, "increment.i");
             _ipSender!.Timing(Timed, "timer.i");
             _ipSender!.Gauge(354654, "gauge.i");
-            _ipSender.Gauge(25.1, "free-space.i");
+            _ipSender!.Gauge(25.1, "free-space.i");
         }
 
         [Benchmark]
         public void RunIPWithSampling()
         {
             _ipSender!.Increment(2, 0.2, "increment.i");
-            _ipSender.Timing(2, 0.2, "increment.i");
+            _ipSender!.Timing(2, 0.2, "increment.i");
         }
 
         [Benchmark]
@@ -90,14 +90,14 @@ namespace Benchmark
             _udpSender!.Increment(20, "increment.u");
             _udpSender!.Timing(Timed, "timer.u");
             _udpSender!.Gauge(354654, "gauge.u");
-            _udpSender.Gauge(25.1, "free-space.u");
+            _udpSender!.Gauge(25.1, "free-space.u");
         }
 
         [Benchmark]
         public void RunUdpWithSampling()
         {
             _udpSender!.Increment(2, 0.2, "increment.u");
-            _udpSender.Timing(2, 0.2, "increment.u");
+            _udpSender!.Timing(2, 0.2, "increment.u");
         }
     }
 }

--- a/tests/Benchmark/Utf8FormatterBenchmark.cs
+++ b/tests/Benchmark/Utf8FormatterBenchmark.cs
@@ -1,21 +1,72 @@
+using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using JustEat.StatsD;
 using JustEat.StatsD.Buffered;
+using JustEat.StatsD.TagsFormatters;
 
 namespace Benchmark
 {
     [MemoryDiagnoser]
     public class Utf8FormatterBenchmark
     {
-        private static readonly StatsDUtf8Formatter FormatterBuffer = new StatsDUtf8Formatter("hello.world");
+        private static readonly StatsDUtf8Formatter FormatterBuffer = new StatsDUtf8Formatter("hello.world", new NoOpTagsFormatter());
+        private static readonly StatsDUtf8Formatter FormatterWithTagsBuffer = new StatsDUtf8Formatter("hello.world", TagsFormatter.DataDog);
+
+        private static readonly Dictionary<string, string?> EmptyTags = new Dictionary<string, string?>();
+        private static readonly Dictionary<string, string?> AnyValidTags = new Dictionary<string, string?>
+        {
+            ["key"] = "value",
+            ["key2"] = "value2",
+        };
 
         private static readonly byte[] Buffer = new byte[512];
 
         [Benchmark]
         public void BufferBased()
         {
-            FormatterBuffer.TryFormat(StatsDMessage.Gauge(255, "some.neat.bucket"), 1, Buffer, out _);
-            FormatterBuffer.TryFormat(StatsDMessage.Timing(255, "some.neat.bucket"), 1, Buffer, out _);
-            FormatterBuffer.TryFormat(StatsDMessage.Counter(255, "some.neat.bucket"), 1, Buffer, out _);
+            FormatterBuffer.TryFormat(StatsDMessage.Gauge(255, "some.neat.bucket", null), 1, Buffer, out _);
+            FormatterBuffer.TryFormat(StatsDMessage.Timing(255, "some.neat.bucket", null), 1, Buffer, out _);
+            FormatterBuffer.TryFormat(StatsDMessage.Counter(255, "some.neat.bucket", null), 1, Buffer, out _);
+        }
+
+        [Benchmark]
+        public void BufferBasedIgnoringTags()
+        {
+            FormatterBuffer.TryFormat(StatsDMessage.Gauge(255, "some.neat.bucket", AnyValidTags), 1, Buffer, out _);
+            FormatterBuffer.TryFormat(StatsDMessage.Timing(255, "some.neat.bucket", AnyValidTags), 1, Buffer, out _);
+            FormatterBuffer.TryFormat(StatsDMessage.Counter(255, "some.neat.bucket", AnyValidTags), 1, Buffer, out _);
+        }
+
+        [Benchmark]
+        public void BufferBasedIgnoringEmptyTags()
+        {
+            FormatterBuffer.TryFormat(StatsDMessage.Gauge(255, "some.neat.bucket", EmptyTags), 1, Buffer, out _);
+            FormatterBuffer.TryFormat(StatsDMessage.Timing(255, "some.neat.bucket", EmptyTags), 1, Buffer, out _);
+            FormatterBuffer.TryFormat(StatsDMessage.Counter(255, "some.neat.bucket", EmptyTags), 1, Buffer, out _);
+        }
+
+        [Benchmark]
+        public void BufferBasedWithTagsFormatterAndNullTags()
+        {
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Gauge(255, "some.neat.bucket", null), 1, Buffer, out _);
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Timing(255, "some.neat.bucket", null), 1, Buffer, out _);
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Counter(255, "some.neat.bucket", null), 1, Buffer, out _);
+        }
+
+        [Benchmark]
+        public void BufferBasedWithTagsFormatter()
+        {
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Gauge(255, "some.neat.bucket", AnyValidTags), 1, Buffer, out _);
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Timing(255, "some.neat.bucket", AnyValidTags), 1, Buffer, out _);
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Counter(255, "some.neat.bucket", AnyValidTags), 1, Buffer, out _);
+        }
+
+        [Benchmark]
+        public void BufferBasedWithTagsFormatterAndEmptyTags()
+        {
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Gauge(255, "some.neat.bucket", EmptyTags), 1, Buffer, out _);
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Timing(255, "some.neat.bucket", EmptyTags), 1, Buffer, out _);
+            FormatterWithTagsBuffer.TryFormat(StatsDMessage.Counter(255, "some.neat.bucket", EmptyTags), 1, Buffer, out _);
         }
     }
 }

--- a/tests/JustEat.StatsD.Tests/Buffered/BufferBasedStatsDPublisherTests.cs
+++ b/tests/JustEat.StatsD.Tests/Buffered/BufferBasedStatsDPublisherTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Moq;
 using Xunit;
 
@@ -16,7 +17,7 @@ namespace JustEat.StatsD.Buffered
             var publisher = new BufferBasedStatsDPublisher(configuration, transport.Object);
 
             // Act
-            publisher.Increment(1, 1, null!);
+            publisher.Increment(1, 1, null!, null);
 
             // Assert
             transport.Verify((p) => p.Send(It.Ref<ArraySegment<byte>>.IsAny), Times.Never());

--- a/tests/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/tests/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -16,26 +16,26 @@ namespace JustEat.StatsD.Extensions
 
         public TimeSpan LastDuration { get; set; }
 
-        public List<string> BucketNames { get; private set; }
+        public List<string> BucketNames { get; }
 
         public void Dispose()
         {
             DisposeCount++;
         }
 
-        public void Increment(long value, double sampleRate, string bucket)
+        public void Increment(long value, double sampleRate, string bucket, Dictionary<string, string?>? tags)
         {
             CallCount++;
             BucketNames.Add(bucket);
         }
 
-        public void Gauge(double value, string bucket)
+        public void Gauge(double value, string bucket, Dictionary<string, string?>? tags)
         {
             CallCount++;
             BucketNames.Add(bucket);
         }
 
-        public void Timing(long duration, double sampleRate, string bucket)
+        public void Timing(long duration, double sampleRate, string bucket, Dictionary<string, string?>? tags)
         {
             CallCount++;
             LastDuration = TimeSpan.FromMilliseconds(duration);

--- a/tests/JustEat.StatsD.Tests/TimerExtensionsTests.cs
+++ b/tests/JustEat.StatsD.Tests/TimerExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Moq;
 using Shouldly;
@@ -137,7 +138,10 @@ namespace JustEat.StatsD
 
             // Assert
             timed.ShouldBeTrue();
-            publisher.Verify((p) => p.Timing(It.IsAny<long>(), 1, bucket), Times.Once());
+            publisher.Verify(
+                (p) => p.Timing(It.IsAny<long>(), 1, bucket,
+                    It.IsAny<Dictionary<string, string?>>()),
+                    Times.Once());
         }
 
         [Fact]
@@ -160,7 +164,10 @@ namespace JustEat.StatsD
 
             // Assert
             actual.ShouldBe(42);
-            publisher.Verify((p) => p.Timing(It.IsAny<long>(), 1, bucket), Times.Once());
+            publisher.Verify(
+                (p) => p.Timing(It.IsAny<long>(), 1, bucket,
+                    It.IsAny<Dictionary<string, string?>>()),
+                    Times.Once());
         }
 
         [Fact]
@@ -187,7 +194,10 @@ namespace JustEat.StatsD
 
             // Assert
             timed.ShouldBeTrue();
-            publisher.Verify((p) => p.Timing(It.IsAny<long>(), 1, bucket), Times.Once());
+            publisher.Verify(
+                (p) => p.Timing(It.IsAny<long>(), 1, bucket,
+                    It.IsAny<Dictionary<string, string?>>()),
+                    Times.Once());
         }
 
         [Fact]
@@ -210,7 +220,10 @@ namespace JustEat.StatsD
 
             // Assert
             actual.ShouldBe(42);
-            publisher.Verify((p) => p.Timing(It.IsAny<long>(), 1, bucket), Times.Once());
+            publisher.Verify(
+                (p) => p.Timing(It.IsAny<long>(), 1, bucket,
+                    It.IsAny<Dictionary<string, string?>>()),
+                    Times.Once());
         }
     }
 }

--- a/tests/JustEat.StatsD.Tests/Utf8FormatterTests.cs
+++ b/tests/JustEat.StatsD.Tests/Utf8FormatterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using JustEat.StatsD.Buffered;
+using JustEat.StatsD.TagsFormatters;
 using Shouldly;
 using Xunit;
 
@@ -9,54 +10,54 @@ namespace JustEat.StatsD
     public static class Utf8FormatterTests
     {
         private static readonly byte[] Buffer = new byte[512];
-        private static readonly StatsDUtf8Formatter Formatter = new StatsDUtf8Formatter("prefix");
+        private static readonly StatsDUtf8Formatter Formatter = new StatsDUtf8Formatter("prefix", new NoOpTagsFormatter());
 
         [Fact]
         public static void CounterSampled()
         {
-            var message = StatsDMessage.Counter(128, "bucket");
+            var message = StatsDMessage.Counter(128, "bucket", null);
             Check(message, 0.5, "prefix.bucket:128|c|@0.5");
         }
 
         [Fact]
         public static void CounterRegular()
         {
-            var message = StatsDMessage.Counter(128, "bucket");
+            var message = StatsDMessage.Counter(128, "bucket", null);
             Check(message, "prefix.bucket:128|c");
         }
 
         [Fact]
         public static void CounterNegative()
         {
-            var message = StatsDMessage.Counter(-128, "bucket");
+            var message = StatsDMessage.Counter(-128, "bucket", null);
             Check(message, "prefix.bucket:-128|c");
         }
 
         [Fact]
         public static void Timing()
         {
-            var message = StatsDMessage.Timing(128, "bucket");
+            var message = StatsDMessage.Timing(128, "bucket", null);
             Check(message, "prefix.bucket:128|ms");
         }
 
         [Fact]
         public static void TimingSampled()
         {
-            var message = StatsDMessage.Timing(128, "bucket");
+            var message = StatsDMessage.Timing(128, "bucket", null);
             Check(message, 0.5, "prefix.bucket:128|ms|@0.5");
         }
 
         [Fact]
         public static void GaugeIntegral()
         {
-            var message = StatsDMessage.Gauge(128, "bucket");
+            var message = StatsDMessage.Gauge(128, "bucket", null);
             Check(message, "prefix.bucket:128|g");
         }
 
         [Fact]
         public static void GaugeFloat()
         {
-            var message = StatsDMessage.Gauge(128.5, "bucket");
+            var message = StatsDMessage.Gauge(128.5, "bucket", null);
             Check(message, "prefix.bucket:128.5|g");
         }
 
@@ -65,7 +66,7 @@ namespace JustEat.StatsD
         {
             var buffer = new byte[128];
             var hugeBucket = new string('x', 256);
-            var message = StatsDMessage.Gauge(128.5, hugeBucket);
+            var message = StatsDMessage.Gauge(128.5, hugeBucket, null);
             Formatter.TryFormat(message, 1.0, buffer, out int written).ShouldBe(false);
             written.ShouldBe(0);
         }
@@ -98,7 +99,7 @@ namespace JustEat.StatsD
         public static void GetMaxBufferSizeCalculatesValidBufferSizes(int bucketSize, char ch)
         {
             var hugeBucket = new string(ch, bucketSize);
-            var message = StatsDMessage.Gauge(128.5, hugeBucket);
+            var message = StatsDMessage.Gauge(128.5, hugeBucket, null);
             var expected = $"prefix.{hugeBucket}:128.5|g";
 
             var buffer = new byte[Formatter.GetMaxBufferSize(message)];

--- a/tests/JustEat.StatsD.Tests/Utf8TagsFormatterTests.cs
+++ b/tests/JustEat.StatsD.Tests/Utf8TagsFormatterTests.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using JustEat.StatsD.Buffered;
+using JustEat.StatsD.TagsFormatters;
+using Shouldly;
+using Xunit;
+
+namespace JustEat.StatsD
+{
+    public static class Utf8TagsFormatterTests
+    {
+        private static readonly byte[] Buffer = new byte[512];
+        private static readonly Dictionary<string, string?> AnyValidTags = new Dictionary<string, string?>
+        {
+            ["foo"] = "bar",
+            ["empty"] = null,
+            ["lorem"] = "ipsum",
+        };
+        
+        [Theory]
+        [InlineData(TagsFormatter.NoOp, "prefix.bucket:128|c|@0.5")]
+        [InlineData(TagsFormatter.Trailing, "prefix.bucket:128|c|@0.5|#foo:bar,empty,lorem:ipsum")]
+        [InlineData(TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|c|@0.5")]
+        [InlineData(TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|c|@0.5")]
+        [InlineData(TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|c|@0.5")]
+        public static void CounterSampled(TagsFormatter tagsFormatter, string expected)
+        {
+            var message = StatsDMessage.Counter(128, "bucket", AnyValidTags);
+            Check(message, 0.5, tagsFormatter, expected);
+        }
+        
+        [Theory]
+        [InlineData(TagsFormatter.NoOp, "prefix.bucket:128|c")]
+        [InlineData(TagsFormatter.Trailing, "prefix.bucket:128|c|#foo:bar,empty,lorem:ipsum")]
+        [InlineData(TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|c")]
+        [InlineData(TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|c")]
+        [InlineData(TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|c")]
+        public static void CounterRegular(TagsFormatter tagsFormatter, string expected)
+        {
+            var message = StatsDMessage.Counter(128, "bucket", AnyValidTags);
+            Check(message, tagsFormatter, expected);
+        }
+        
+        [Theory]
+        [InlineData(TagsFormatter.NoOp, "prefix.bucket:-128|c")]
+        [InlineData(TagsFormatter.Trailing, "prefix.bucket:-128|c|#foo:bar,empty,lorem:ipsum")]
+        [InlineData(TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:-128|c")]
+        [InlineData(TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:-128|c")]
+        [InlineData(TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:-128|c")]
+        public static void CounterNegative(TagsFormatter tagsFormatter, string expected)
+        {
+            var message = StatsDMessage.Counter(-128, "bucket", AnyValidTags);
+            Check(message, tagsFormatter, expected);
+        }
+        
+        [Theory]
+        [InlineData(TagsFormatter.NoOp, "prefix.bucket:128|c")]
+        [InlineData(TagsFormatter.Trailing, "prefix.bucket:128|c")]
+        [InlineData(TagsFormatter.InfluxDb, "prefix.bucket:128|c")]
+        [InlineData(TagsFormatter.Librato, "prefix.bucket:128|c")]
+        [InlineData(TagsFormatter.SignalFx, "prefix.bucket:128|c")]
+        public static void CounterWithoutTags(TagsFormatter tagsFormatter, string expected)
+        {
+            var message = StatsDMessage.Counter(128, "bucket", null);
+            Check(message, tagsFormatter, expected);
+        }
+        
+        [Theory]
+        [InlineData(TagsFormatter.NoOp, "prefix.bucket:128|ms")]
+        [InlineData(TagsFormatter.Trailing, "prefix.bucket:128|ms|#foo:bar,empty,lorem:ipsum")]
+        [InlineData(TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|ms")]
+        [InlineData(TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|ms")]
+        [InlineData(TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|ms")]
+        public static void Timing(TagsFormatter tagsFormatter, string expected)
+        {
+            var message = StatsDMessage.Timing(128, "bucket", AnyValidTags);
+            Check(message, tagsFormatter, expected);
+        }
+        
+        [Theory]
+        [InlineData(TagsFormatter.NoOp, "prefix.bucket:128|ms|@0.5")]
+        [InlineData(TagsFormatter.Trailing, "prefix.bucket:128|ms|@0.5|#foo:bar,empty,lorem:ipsum")]
+        [InlineData(TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|ms|@0.5")]
+        [InlineData(TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|ms|@0.5")]
+        [InlineData(TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|ms|@0.5")]
+        public static void TimingSampled(TagsFormatter tagsFormatter, string expected)
+        {
+            var message = StatsDMessage.Timing(128, "bucket", AnyValidTags);
+            Check(message, 0.5, tagsFormatter, expected);
+        }
+        
+        [Theory]
+        [InlineData(TagsFormatter.NoOp, "prefix.bucket:128|g")]
+        [InlineData(TagsFormatter.Trailing, "prefix.bucket:128|g|#foo:bar,empty,lorem:ipsum")]
+        [InlineData(TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128|g")]
+        [InlineData(TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128|g")]
+        [InlineData(TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128|g")]
+        public static void GaugeIntegral(TagsFormatter tagsFormatter, string expected)
+        {
+            var message = StatsDMessage.Gauge(128, "bucket", AnyValidTags);
+            Check(message, tagsFormatter, expected);
+        }
+        
+        [Theory]
+        [InlineData(TagsFormatter.NoOp, "prefix.bucket:128.5|g")]
+        [InlineData(TagsFormatter.Trailing, "prefix.bucket:128.5|g|#foo:bar,empty,lorem:ipsum")]
+        [InlineData(TagsFormatter.InfluxDb, "prefix.bucket,foo=bar,empty,lorem=ipsum:128.5|g")]
+        [InlineData(TagsFormatter.Librato, "prefix.bucket#foo=bar,empty,lorem=ipsum:128.5|g")]
+        [InlineData(TagsFormatter.SignalFx, "prefix.bucket[foo=bar,empty,lorem=ipsum]:128.5|g")]
+        public static void GaugeFloat(TagsFormatter tagsFormatter, string expected)
+        {
+            var message = StatsDMessage.Gauge(128.5, "bucket", AnyValidTags);
+            Check(message, tagsFormatter, expected);
+        }
+
+        [Theory]
+        [InlineData(1, 'z')]
+        [InlineData(2, 'z')]
+        [InlineData(4, 'z')]
+        [InlineData(8, 'z')]
+        [InlineData(16, 'z')]
+        [InlineData(32, 'z')]
+        [InlineData(64, 'z')]
+        [InlineData(128, 'z')]
+        [InlineData(256, 'z')]
+        [InlineData(512, 'z')]
+        [InlineData(1024, 'z')]
+        [InlineData(2048, 'z')]
+        [InlineData(1, 'Ж')]
+        [InlineData(2, 'Ж')]
+        [InlineData(4, 'Ж')]
+        [InlineData(8, 'Ж')]
+        [InlineData(16, 'Ж')]
+        [InlineData(32, 'Ж')]
+        [InlineData(64, 'Ж')]
+        [InlineData(128, 'Ж')]
+        [InlineData(256, 'Ж')]
+        [InlineData(512, 'Ж')]
+        [InlineData(1024, 'Ж')]
+        [InlineData(2048, 'Ж')]
+        public static void GetMaxBufferSizeCalculatesValidBufferSizesWithTags(int size, char ch)
+        {
+            // Arrange
+            var hugeBucket = new string(ch, size);
+            var hugeTag = new string(ch, size);
+            var anyValidTags = new Dictionary<string, string?> { [hugeTag] = null };
+            var message = StatsDMessage.Gauge(128.5, hugeBucket, anyValidTags);
+
+            var expected = $"prefix.{hugeBucket}:128.5|g|#{hugeTag}";
+
+            var anyTagsFormatter = TagsFormatter.Trailing;
+            var formatter = GetStatsDUtf8Formatter(anyTagsFormatter);
+
+            // Act
+            var buffer = new byte[formatter.GetMaxBufferSize(message)];
+
+            // Assert
+            formatter.TryFormat(message, 1.0, buffer, out int written).ShouldBe(true);
+            var actual = Encoding.UTF8.GetString(buffer.AsSpan(0, written));
+            actual.ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(1, 'z')]
+        [InlineData(16, 'z')]
+        [InlineData(256, 'z')]
+        public static void GetMaxBufferSizeCalculatesValidBufferSizesWithoutTags(int bucketSize, char ch)
+        {
+            // Arrange
+            var hugeBucket = new string(ch, bucketSize);
+            var message = StatsDMessage.Gauge(128.5, hugeBucket, null);
+
+            var expected = $"prefix.{hugeBucket}:128.5|g";
+
+            var anyTagsFormatter = TagsFormatter.Trailing;
+            var formatter = GetStatsDUtf8Formatter(anyTagsFormatter);
+            
+            // Act
+            var buffer = new byte[formatter.GetMaxBufferSize(message)];
+            
+            // Assert
+            formatter.TryFormat(message, 1.0, buffer, out int written).ShouldBe(true);
+            var actual = Encoding.UTF8.GetString(buffer.AsSpan(0, written));
+            actual.ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData(1, 'z')]
+        [InlineData(16, 'z')]
+        [InlineData(256, 'z')]
+        public static void GetMaxBufferSizeCalculatesValidBufferSizesIgnoringTags(int bucketSize, char ch)
+        {
+            // Arrange
+            var hugeBucket = new string(ch, bucketSize);
+            var message = StatsDMessage.Gauge(128.5, hugeBucket, AnyValidTags);
+
+            var expected = $"prefix.{hugeBucket}:128.5|g";
+
+            var formatter = GetStatsDUtf8Formatter();
+            
+            // Act
+            var buffer = new byte[formatter.GetMaxBufferSize(message)];
+            
+            // Assert
+            formatter.TryFormat(message, 1.0, buffer, out int written).ShouldBe(true);
+            var actual = Encoding.UTF8.GetString(buffer.AsSpan(0, written));
+            actual.ShouldBe(expected);
+        }
+
+        [Fact]
+        public static void CounterWithNullFormattedTags()
+        {
+            // Arrange
+            var nullTagsFormatterMock = new AlwaysNullStatsDTagsFormatter();
+            var formatter = GetStatsDUtf8Formatter(nullTagsFormatterMock);
+            var message = StatsDMessage.Counter(128, "bucket", AnyValidTags);
+
+            // Act and assert
+            Check(message, 0.5, formatter, "prefix.bucket:128|c|@0.5");
+        }
+
+        [Fact]
+        public static void TimingWithNullFormattedTags()
+        {
+            // Arrange
+            var nullTagsFormatterMock = new AlwaysNullStatsDTagsFormatter();
+            var formatter = GetStatsDUtf8Formatter(nullTagsFormatterMock);
+            var message = StatsDMessage.Timing(128, "bucket", AnyValidTags);
+
+            // Act and assert
+            Check(message, 0.5, formatter, "prefix.bucket:128|ms|@0.5");
+        }
+
+        [Fact]
+        public static void GaugeWithNullFormattedTags()
+        {
+            // Arrange
+            var nullTagsFormatterMock = new AlwaysNullStatsDTagsFormatter();
+            var formatter = GetStatsDUtf8Formatter(nullTagsFormatterMock);
+            var message = StatsDMessage.Gauge(128, "bucket", AnyValidTags);
+
+            // Act and assert
+            Check(message, formatter, "prefix.bucket:128|g");
+        }
+
+        private static void Check(StatsDMessage message, TagsFormatter tagsFormatter, string expected)
+        {
+            Check(message, 1, tagsFormatter, expected);
+        }
+
+        private static void Check(StatsDMessage message, double sampleRate, TagsFormatter tagsFormatter, string expected)
+        {
+            var formatter = GetStatsDUtf8Formatter(tagsFormatter);
+            Check(message, sampleRate, formatter, expected);
+        }
+        
+        private static void Check(StatsDMessage message, StatsDUtf8Formatter formatter, string expected)
+        {
+            Check(message, 1, formatter, expected);
+        }
+
+        private static void Check(StatsDMessage message, double sampleRate, StatsDUtf8Formatter formatter, string expected)
+        {
+            formatter.TryFormat(message, sampleRate, Buffer, out int written).ShouldBe(true);
+            var result = Encoding.UTF8.GetString(Buffer.AsSpan(0, written));
+            result.ShouldBe(expected);
+        }
+
+        private static StatsDUtf8Formatter GetStatsDUtf8Formatter(TagsFormatter tagsFormatter = TagsFormatter.NoOp)
+        {
+            IStatsDTagsFormatter statsDTagsFormatter = tagsFormatter switch
+            {
+                TagsFormatter.NoOp => new NoOpTagsFormatter(),
+                TagsFormatter.Trailing => JustEat.StatsD.TagsFormatter.CloudWatch,
+                TagsFormatter.InfluxDb => JustEat.StatsD.TagsFormatter.InfluxDb,
+                TagsFormatter.Librato => JustEat.StatsD.TagsFormatter.Librato,
+                TagsFormatter.SignalFx => JustEat.StatsD.TagsFormatter.SignalFx,
+                _ => throw new ArgumentOutOfRangeException(nameof(tagsFormatter))
+            };
+
+            return GetStatsDUtf8Formatter(statsDTagsFormatter);
+        }
+
+        private static StatsDUtf8Formatter GetStatsDUtf8Formatter(IStatsDTagsFormatter tagsFormatter)
+        {
+            return new StatsDUtf8Formatter("prefix", tagsFormatter);
+        }
+
+        public enum TagsFormatter
+        {
+            NoOp,
+            Trailing,
+            InfluxDb,
+            Librato,
+            SignalFx,
+        }
+
+        private class AlwaysNullStatsDTagsFormatter : IStatsDTagsFormatter
+        {
+            public bool AreTrailing { get; }
+
+            public int GetTagsBufferSize(in Dictionary<string, string?> tags) => 0;
+
+            public ReadOnlySpan<char> FormatTags(in Dictionary<string, string?> tags) => null;
+        }
+    }
+}

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <VersionPrefix>4.2.0</VersionPrefix>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' AND '$(GITHUB_ACTIONS)' != '' ">beta$([System.Convert]::ToInt32(`$(GITHUB_RUN_NUMBER)`).ToString(`0000`))</VersionSuffix>
     <VersionPrefix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) ">$(GITHUB_REF.Replace('refs/tags/v', ''))</VersionPrefix>
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>


### PR DESCRIPTION
Support of tags or dimensions for the following providers:

- [DataDog](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics), [Splunk](https://docs.splunk.com/Documentation/Splunk/8.0.5/Metrics/GetMetricsInStatsd) and [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-custom-metrics-statsd.html).
- [InfluxDB](https://www.influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb/#introducing-influx-statsd).
- [Librato](https://github.com/librato/statsd-librato-backend#tags).
- [SignalFX](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-statsd.html#adding-dimensions-to-statsd-metrics).

It covers issue: #268 

It contains a breaking change. The interface `IStatsDPublisher` has been modified to include the tags as `Dictionary<string, string?>`. The old methods of this interface have been included as extension methods at `IStatsDPublisherExtensions`.
Therefore:
- Implementations of `IStatsDPublisher` will be broken after the change.
- Former usage of `IStatsDPublisher` and `StatsDPublisher` will work as it was in the previous version.

## Benchmarking

### After the change
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1016 (1909/November2018Update/19H2)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.401
  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT


```
|                                   Method |     Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------------- |---------:|--------:|--------:|------:|------:|------:|----------:|
|                              BufferBased | 248.0 ns | 4.58 ns | 4.29 ns |     - |     - |     - |         - |
|                  BufferBasedIgnoringTags | 272.0 ns | 3.61 ns | 3.01 ns |     - |     - |     - |         - |
|             BufferBasedIgnoringEmptyTags | 256.3 ns | 5.16 ns | 5.94 ns |     - |     - |     - |         - |
|  BufferBasedWithTagsFormatterAndNullTags | 248.9 ns | 4.86 ns | 5.59 ns |     - |     - |     - |         - |
|             BufferBasedWithTagsFormatter | 661.2 ns | 4.65 ns | 4.35 ns |     - |     - |     - |         - |
| BufferBasedWithTagsFormatterAndEmptyTags | 252.7 ns | 3.36 ns | 2.98 ns |     - |     - |     - |         - |


### Previous version
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.1016 (1909/November2018Update/19H2)
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.401
  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT


```
|      Method |     Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|--------:|--------:|------:|------:|------:|----------:|
| BufferBased | 226.8 ns | 4.48 ns | 3.97 ns |     - |     - |     - |         - |
