### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,11 +19,11 @@ If you wish to contribute code, please consider the guidelines below:
   1. Test coverage should not go down.
   1. Note any breaking changes in your PR description.
   1. Ensure `build.ps1` runs with no errors or warnings and all the tests pass.
-  1. Open a pull request against the `master` branch, referencing your issue, if appropriate.
+  1. Open a pull request against the `main` branch, referencing your issue, if appropriate.
 
 Once your pull request is opened, the project maintainers will assess it for validity and an appropriate level of quality. For example, the Pull Request status checks should all be green.
 
-If the project maintainers are satisfied that your contribution is appropriate it will be merged into the master branch when appropriate and it will then be released when the library is next published to [NuGet](https://www.nuget.org/profiles/JUSTEAT_OSS).
+If the project maintainers are satisfied that your contribution is appropriate it will be merged into the main branch when appropriate and it will then be released when the library is next published to [NuGet](https://www.nuget.org/profiles/JUSTEAT_OSS).
 
 ## Releases
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     tags: [ v* ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![NuGet version](https://buildstats.info/nuget/JustEat.StatsD?includePreReleases=false)](http://www.nuget.org/packages/JustEat.StatsD)
 
-[![Build status](https://github.com/justeat/JustEat.StatsD/workflows/build/badge.svg?branch=master&event=push)](https://github.com/justeat/JustEat.StatsD/actions?query=workflow%3Abuild+branch%3Amaster+event%3Apush)
+[![Build status](https://github.com/justeat/JustEat.StatsD/workflows/build/badge.svg?branch=main&event=push)](https://github.com/justeat/JustEat.StatsD/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
 
-[![codecov](https://codecov.io/gh/justeat/JustEat.StatsD/branch/master/graph/badge.svg)](https://codecov.io/gh/justeat/JustEat.StatsD)
+[![codecov](https://codecov.io/gh/justeat/JustEat.StatsD/branch/main/graph/badge.svg)](https://codecov.io/gh/justeat/JustEat.StatsD)
 
 ## Summary
 


### PR DESCRIPTION
Update the name of the default branch in the repo to `main`.

Will merge after doing the _actual_ rename in the repo settings.
