### PR TITLE
Fix code coverage result upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: codecov/codecov-action@v1
       name: Upload coverage to Codecov
       with:
-        file: ./artifacts/coverage.netcoreapp3.1.cobertura.xml
+        file: ./artifacts/coverage.net5.0.cobertura.xml
         flags: ${{ matrix.os_name }}
 
     - name: Publish artifacts

--- a/build.ps1
+++ b/build.ps1
@@ -100,7 +100,7 @@ function DotNetTest {
     $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageVersion[@Include='ReportGenerator']/@Version").Node.'#text'
     $reportGeneratorPath = Join-Path $nugetPath "reportgenerator\$reportGeneratorVersion\tools\netcoreapp3.0\ReportGenerator.dll"
 
-    $coverageOutput = Join-Path $OutputPath "coverage.netcoreapp3.1.cobertura.xml"
+    $coverageOutput = Join-Path $OutputPath "coverage.net5.0.cobertura.xml"
     $reportOutput = Join-Path $OutputPath "coverage"
 
     & $dotnet test $Project --output $OutputPath


### PR DESCRIPTION
Fix code coverage results not being uploaded to codecov.io which was broken by #280 because the TFM of the tests changed, which then meant it wasn't finding the output file.
