### PR TITLE
Deterministics builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
     <Authors>JUSTEAT_OSS</Authors>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)JustEat.StatsD.ruleset</CodeAnalysisRuleSet>
     <Company>Just Eat</Company>
+    <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>
     <Copyright>Copyright (c) Just Eat 2015-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,2 @@
 <Project>
-  <!-- Disable sourcelink on mono, to workaround https://github.com/dotnet/sourcelink/issues/155 -->
-  <Target Name="_RemoveMSSourceLinkGitHub" AfterTargets="CollectPackageReferences" Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">
-    <ItemGroup>
-      <PackageReference Remove="Microsoft.SourceLink.GitHub" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
* Set `ContinuousIntegrationBuild` in CI.
* Remove workaround for Sourcelink that should be redundant now.
