### PR TITLE
.NET 6 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: codecov/codecov-action@v1
       name: Upload coverage to Codecov
       with:
-        file: ./artifacts/coverage.net5.0.cobertura.xml
+        file: ./artifacts/coverage.net6.0.cobertura.xml
         flags: ${{ matrix.os_name }}
 
     - name: Publish artifacts

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,7 @@
     <Deterministic>true</Deterministic>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnablePackageValidation>true</EnablePackageValidation>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <LangVersion>latest</LangVersion>
@@ -27,6 +28,10 @@
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>statsd,graphite,metrics,monitoring</PackageTags>
+    <!-- TODO Enable when v5 ships -->
+    <!--
+    <PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>
+    -->
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
     <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.StatsD' ">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0-rc.1.21451.13" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0-rc.1.21451.13" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0-rc.2.21480.5" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
     <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.StatsD' ">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0-rc.1.21451.13" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0-rc.1.21451.13" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,8 +22,8 @@
     <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.StatsD' ">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0-rc.2.21480.5" />
-    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0-rc.2.21480.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />

--- a/JustEat.StatsD.sln
+++ b/JustEat.StatsD.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29215.179
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31717.71
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{06BE4D4A-B0DF-465D-9BAC-6CC3C9779A37}"
 	ProjectSection(SolutionItems) = preProject
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{06BE4D
 		global.json = global.json
 		JustEat.StatsD.ruleset = JustEat.StatsD.ruleset
 		LICENSE = LICENSE
+		NuGet.config = NuGet.config
 		README.md = README.md
 		version.props = version.props
 	EndProjectSection

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <!-- TODO Remove once .NET 6 is officially released -->
-    <add key="darc-pub-dotnet-aspnetcore-ae1a6cb-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-ae1a6cbe-1/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-runtime-4822e3c-5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-4822e3c3-5/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-windowsdesktop-59fea7d-4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-windowsdesktop-59fea7da-4/nuget/v3/index.json" />
-    <!-- </TODO> -->
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <!-- TODO Remove once .NET 6 is officially released -->
+    <add key="darc-pub-dotnet-aspnetcore-ae1a6cb-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-ae1a6cbe-1/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-runtime-4822e3c-5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-4822e3c3-5/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-windowsdesktop-59fea7d-4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-windowsdesktop-59fea7da-4/nuget/v3/index.json" />
+    <!-- </TODO> -->
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ We use this library within our components to publish [StatsD](http://github.com/
 * `net461`
 * `netstandard2.0`
 * `netstandard2.1`
-* `netcoreapp2.1`
 * `net5.0`
 
 ### Features

--- a/build.ps1
+++ b/build.ps1
@@ -98,9 +98,9 @@ function DotNetTest {
     $nugetPath = Join-Path ($env:USERPROFILE ?? "~") ".nuget\packages"
     $propsFile = Join-Path $solutionPath "Directory.Packages.props"
     $reportGeneratorVersion = (Select-Xml -Path $propsFile -XPath "//PackageVersion[@Include='ReportGenerator']/@Version").Node.'#text'
-    $reportGeneratorPath = Join-Path $nugetPath "reportgenerator\$reportGeneratorVersion\tools\netcoreapp3.0\ReportGenerator.dll"
+    $reportGeneratorPath = Join-Path $nugetPath "reportgenerator\$reportGeneratorVersion\tools\net5.0\ReportGenerator.dll"
 
-    $coverageOutput = Join-Path $OutputPath "coverage.net5.0.cobertura.xml"
+    $coverageOutput = Join-Path $OutputPath "coverage.*.cobertura.xml"
     $reportOutput = Join-Path $OutputPath "coverage"
 
     & $dotnet test $Project --output $OutputPath

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.1.21463.6",
+    "version": "6.0.100-rc.2.21505.57",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-rc.2.21505.57",
+    "version": "6.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.402",
+    "version": "6.0.100-rc.1.21463.6",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/JustEat.StatsD/Buffered/Buffer.cs
+++ b/src/JustEat.StatsD/Buffered/Buffer.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace JustEat.StatsD.Buffered
 {
     internal ref struct Buffer<T>

--- a/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
+++ b/src/JustEat.StatsD/Buffered/BufferBasedStatsDPublisher.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace JustEat.StatsD.Buffered
 {
     internal sealed class BufferBasedStatsDPublisher : IStatsDPublisher

--- a/src/JustEat.StatsD/Buffered/BufferExtensions.cs
+++ b/src/JustEat.StatsD/Buffered/BufferExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Buffers.Text;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;

--- a/src/JustEat.StatsD/Buffered/StatsDMessage.cs
+++ b/src/JustEat.StatsD/Buffered/StatsDMessage.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace JustEat.StatsD.Buffered
 {
     internal readonly struct StatsDMessage

--- a/src/JustEat.StatsD/Buffered/StatsDUtf8Formatter.cs
+++ b/src/JustEat.StatsD/Buffered/StatsDUtf8Formatter.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
 using JustEat.StatsD.TagsFormatters;

--- a/src/JustEat.StatsD/ConnectedSocketPool.cs
+++ b/src/JustEat.StatsD/ConnectedSocketPool.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;

--- a/src/JustEat.StatsD/DisposableTimer.cs
+++ b/src/JustEat.StatsD/DisposableTimer.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace JustEat.StatsD

--- a/src/JustEat.StatsD/EndpointLookups/CachedEndpointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/CachedEndpointSource.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 
 namespace JustEat.StatsD.EndpointLookups

--- a/src/JustEat.StatsD/EndpointLookups/DnsLookupIpEndpointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/DnsLookupIpEndpointSource.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 

--- a/src/JustEat.StatsD/EndpointLookups/EndPointFactory.cs
+++ b/src/JustEat.StatsD/EndpointLookups/EndPointFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 
 namespace JustEat.StatsD.EndpointLookups

--- a/src/JustEat.StatsD/EndpointLookups/SimpleEndpointSource.cs
+++ b/src/JustEat.StatsD/EndpointLookups/SimpleEndpointSource.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 
 namespace JustEat.StatsD.EndpointLookups

--- a/src/JustEat.StatsD/IDisposableTimer.cs
+++ b/src/JustEat.StatsD/IDisposableTimer.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace JustEat.StatsD
 {
     /// <summary>

--- a/src/JustEat.StatsD/IStatsDPublisher.cs
+++ b/src/JustEat.StatsD/IStatsDPublisher.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace JustEat.StatsD
 {
     /// <summary>

--- a/src/JustEat.StatsD/IStatsDPublisherExtensions.cs
+++ b/src/JustEat.StatsD/IStatsDPublisherExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace JustEat.StatsD

--- a/src/JustEat.StatsD/IStatsDTransport.cs
+++ b/src/JustEat.StatsD/IStatsDTransport.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace JustEat.StatsD
 {
     /// <summary>

--- a/src/JustEat.StatsD/IStatsDTransportExtensions.cs
+++ b/src/JustEat.StatsD/IStatsDTransportExtensions.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
 

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -7,7 +7,7 @@
     <PackageId>JustEat.StatsD</PackageId>
     <RootNamespace>JustEat.StatsD</RootNamespace>
     <Summary>A .NET library for publishing metrics to StatsD.</Summary>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <!--

--- a/src/JustEat.StatsD/JustEat.StatsD.csproj
+++ b/src/JustEat.StatsD/JustEat.StatsD.csproj
@@ -9,9 +9,19 @@
     <Summary>A .NET library for publishing metrics to StatsD.</Summary>
     <TargetFrameworks>net461;netstandard2.0;netstandard2.1;netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <!--
+      HACK Suppress false-positive warnings:
+      Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Compatibility.Common.targets(32,5): warning CP1002: When loading: 'lib/net461/JustEat.StatsD.dll': Could not resolve reference 'System.ServiceModel.Internals.dll' in any of the provided search directories.
+      Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Compatibility.Common.targets(32,5): warning CP1002: When loading: 'lib/net461/JustEat.StatsD.dll': Could not resolve reference 'SMDiagnostics.dll' in any of the provided search directories.
+    -->
+    <NoWarn>$(NoWarn);CP1002</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/JustEat.StatsD/SocketFactory.cs
+++ b/src/JustEat.StatsD/SocketFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 

--- a/src/JustEat.StatsD/SocketTransport.cs
+++ b/src/JustEat.StatsD/SocketTransport.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
 using JustEat.StatsD.EndpointLookups;
 
 namespace JustEat.StatsD

--- a/src/JustEat.StatsD/StatsDConfiguration.cs
+++ b/src/JustEat.StatsD/StatsDConfiguration.cs
@@ -1,4 +1,3 @@
-using System;
 using JustEat.StatsD.TagsFormatters;
 
 namespace JustEat.StatsD

--- a/src/JustEat.StatsD/StatsDPublisher.cs
+++ b/src/JustEat.StatsD/StatsDPublisher.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using JustEat.StatsD.Buffered;
 using JustEat.StatsD.EndpointLookups;
 

--- a/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
+++ b/src/JustEat.StatsD/StatsDServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using JustEat.StatsD.EndpointLookups;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/JustEat.StatsD/TagsFormatters/IStatsDTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/IStatsDTagsFormatter.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace JustEat.StatsD.TagsFormatters
 {
     /// <summary>

--- a/src/JustEat.StatsD/TagsFormatters/NoOpTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/NoOpTagsFormatter.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace JustEat.StatsD.TagsFormatters
 {
     internal sealed class NoOpTagsFormatter : IStatsDTagsFormatter

--- a/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatter.cs
+++ b/src/JustEat.StatsD/TagsFormatters/StatsDTagsFormatter.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using JustEat.StatsD.Buffered;

--- a/src/JustEat.StatsD/TimerExtensions.cs
+++ b/src/JustEat.StatsD/TimerExtensions.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Threading.Tasks;
 
 namespace JustEat.StatsD
 {

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1001;CA1014;CA1822</NoWarn>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1001;CA1014;CA1822</NoWarn>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Benchmark/Program.cs
+++ b/tests/Benchmark/Program.cs
@@ -1,14 +1,5 @@
 using BenchmarkDotNet.Running;
 
-namespace Benchmark
-{
-    internal static class Program
-    {
-        internal static void Main(string[] args)
-        {
-            BenchmarkSwitcher
-                .FromAssembly(typeof(Program).Assembly)
-                .Run(args);
-        }
-    }
-}
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/tests/Benchmark/StatSendingBenchmark.cs
+++ b/tests/Benchmark/StatSendingBenchmark.cs
@@ -1,5 +1,6 @@
 using System;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using JustEat.StatsD;
 using JustEat.StatsD.Buffered;
 using JustEat.StatsD.EndpointLookups;
@@ -7,6 +8,9 @@ using JustEat.StatsD.EndpointLookups;
 namespace Benchmark
 {
     [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     public class StatSendingBenchmark : IDisposable
     {
         private bool _disposed;

--- a/tests/Benchmark/StatSendingBenchmark.cs
+++ b/tests/Benchmark/StatSendingBenchmark.cs
@@ -1,4 +1,3 @@
-using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using JustEat.StatsD;

--- a/tests/Benchmark/UdpStatSendingBenchmark.cs
+++ b/tests/Benchmark/UdpStatSendingBenchmark.cs
@@ -1,4 +1,3 @@
-using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using JustEat.StatsD;

--- a/tests/Benchmark/UdpStatSendingBenchmark.cs
+++ b/tests/Benchmark/UdpStatSendingBenchmark.cs
@@ -1,5 +1,6 @@
 using System;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using JustEat.StatsD;
 using JustEat.StatsD.Buffered;
 using JustEat.StatsD.EndpointLookups;
@@ -7,6 +8,9 @@ using JustEat.StatsD.EndpointLookups;
 namespace Benchmark
 {
     [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     public class UdpStatSendingBenchmark
     {
         private static readonly TimeSpan Timed = TimeSpan.FromMinutes(1);

--- a/tests/Benchmark/UdpTransportBenchmark.cs
+++ b/tests/Benchmark/UdpTransportBenchmark.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Net;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using JustEat.StatsD;
 using JustEat.StatsD.EndpointLookups;
 
 namespace Benchmark
 {
     [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     public class UdpTransportBenchmark
     {
         private const string MetricName = "this.is.a.metric:1|c";

--- a/tests/Benchmark/UdpTransportBenchmark.cs
+++ b/tests/Benchmark/UdpTransportBenchmark.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;

--- a/tests/Benchmark/Utf8FormatterBenchmark.cs
+++ b/tests/Benchmark/Utf8FormatterBenchmark.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using JustEat.StatsD;

--- a/tests/Benchmark/Utf8FormatterBenchmark.cs
+++ b/tests/Benchmark/Utf8FormatterBenchmark.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using JustEat.StatsD;
 using JustEat.StatsD.Buffered;
 using JustEat.StatsD.TagsFormatters;
@@ -7,6 +8,9 @@ using JustEat.StatsD.TagsFormatters;
 namespace Benchmark
 {
     [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     public class Utf8FormatterBenchmark
     {
         private static readonly StatsDUtf8Formatter FormatterBuffer = new StatsDUtf8Formatter("hello.world", new NoOpTagsFormatter());

--- a/tests/JustEat.StatsD.Tests/BufferBasedStatsDPublisherTests.cs
+++ b/tests/JustEat.StatsD.Tests/BufferBasedStatsDPublisherTests.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
 using System.Text;
 using JustEat.StatsD.Buffered;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/Buffered/BufferBasedStatsDPublisherTests.cs
+++ b/tests/JustEat.StatsD.Tests/Buffered/BufferBasedStatsDPublisherTests.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using Moq;
-using Xunit;
 
 namespace JustEat.StatsD.Buffered
 {

--- a/tests/JustEat.StatsD.Tests/EndpointLookups/CachedEndpointSourceTests.cs
+++ b/tests/JustEat.StatsD.Tests/EndpointLookups/CachedEndpointSourceTests.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Net;
-using System.Threading.Tasks;
 using Moq;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD.EndpointLookups
 {

--- a/tests/JustEat.StatsD.Tests/EndpointLookups/DnsLookupIpEndpointSourceTests.cs
+++ b/tests/JustEat.StatsD.Tests/EndpointLookups/DnsLookupIpEndpointSourceTests.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Net;
 using System.Net.Sockets;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD.EndpointLookups
 {

--- a/tests/JustEat.StatsD.Tests/EndpointLookups/EndPointFactoryTests.cs
+++ b/tests/JustEat.StatsD.Tests/EndpointLookups/EndPointFactoryTests.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Net;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD.EndpointLookups
 {

--- a/tests/JustEat.StatsD.Tests/EndpointLookups/SimpleEndpointTests.cs
+++ b/tests/JustEat.StatsD.Tests/EndpointLookups/SimpleEndpointTests.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Net;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD.EndpointLookups
 {

--- a/tests/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
+++ b/tests/JustEat.StatsD.Tests/Extensions/ExtensionsTests.cs
@@ -1,8 +1,3 @@
-using System.Threading;
-using System.Threading.Tasks;
-using Shouldly;
-using Xunit;
-
 namespace JustEat.StatsD.Extensions
 {
     public static class ExtensionsTests

--- a/tests/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
+++ b/tests/JustEat.StatsD.Tests/Extensions/FakeStatsPublisher.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace JustEat.StatsD.Extensions
 {
     public class FakeStatsPublisher : IStatsDPublisher

--- a/tests/JustEat.StatsD.Tests/Extensions/PublisherAssertions.cs
+++ b/tests/JustEat.StatsD.Tests/Extensions/PublisherAssertions.cs
@@ -1,6 +1,3 @@
-﻿using System;
-using Shouldly;
-
 namespace JustEat.StatsD.Extensions
 {
     public static class PublisherAssertions

--- a/tests/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
+++ b/tests/JustEat.StatsD.Tests/Extensions/SimpleTimerStatNameTests.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Threading;
-using Shouldly;
-using Xunit;
-
 namespace JustEat.StatsD.Extensions
 {
     public static class SimpleTimerStatNameTests

--- a/tests/JustEat.StatsD.Tests/Extensions/TimingConstants.cs
+++ b/tests/JustEat.StatsD.Tests/Extensions/TimingConstants.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace JustEat.StatsD.Extensions
 {
     public static class TimingConstants

--- a/tests/JustEat.StatsD.Tests/IStatsDTransportExtensionsTests.cs
+++ b/tests/JustEat.StatsD.Tests/IStatsDTransportExtensionsTests.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using Moq;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/IntegrationTests.cs
+++ b/tests/JustEat.StatsD.Tests/IntegrationTests.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/IntegrationTests.cs
+++ b/tests/JustEat.StatsD.Tests/IntegrationTests.cs
@@ -94,7 +94,7 @@ namespace JustEat.StatsD
 
             using (var client = new TcpClient())
             {
-                client.Connect("localhost", 8126);
+                await client.ConnectAsync("localhost", 8126);
 
                 byte[] input = Encoding.UTF8.GetBytes(command);
                 byte[] output = new byte[client.ReceiveBufferSize];

--- a/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -20,6 +20,10 @@
     <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
   <ItemGroup>
+    <Using Include="Shouldly" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
+++ b/tests/JustEat.StatsD.Tests/JustEat.StatsD.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);CA1014;CA1002;CA1707;CA1711;CA2007</NoWarn>
     <RootNamespace>JustEat.StatsD</RootNamespace>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\JustEat.StatsD\JustEat.StatsD.csproj" />

--- a/tests/JustEat.StatsD.Tests/SocketTransportTests.cs
+++ b/tests/JustEat.StatsD.Tests/SocketTransportTests.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Net;
 using JustEat.StatsD.EndpointLookups;
 using Moq;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/StatsDPublisherTests.cs
+++ b/tests/JustEat.StatsD.Tests/StatsDPublisherTests.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using Moq;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/TimerExtensionsTests.cs
+++ b/tests/JustEat.StatsD.Tests/TimerExtensionsTests.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Moq;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/UdpListeners.cs
+++ b/tests/JustEat.StatsD.Tests/UdpListeners.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net;
 using System.Net.Sockets;
 

--- a/tests/JustEat.StatsD.Tests/UdpListenersCollection.cs
+++ b/tests/JustEat.StatsD.Tests/UdpListenersCollection.cs
@@ -1,5 +1,3 @@
-using Xunit;
-
 namespace JustEat.StatsD
 {
     [CollectionDefinition("ActiveUdpListeners")]

--- a/tests/JustEat.StatsD.Tests/Utf8FormatterTests.cs
+++ b/tests/JustEat.StatsD.Tests/Utf8FormatterTests.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Text;
 using JustEat.StatsD.Buffered;
 using JustEat.StatsD.TagsFormatters;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/Utf8TagsFormatterTests.cs
+++ b/tests/JustEat.StatsD.Tests/Utf8TagsFormatterTests.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Text;
 using JustEat.StatsD.Buffered;
 using JustEat.StatsD.TagsFormatters;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
+++ b/tests/JustEat.StatsD.Tests/WhenCreatingStatsDPublisher.cs
@@ -1,6 +1,3 @@
-using System;
-using Xunit;
-
 namespace JustEat.StatsD
 {
     public class WhenCreatingStatsDPublisher

--- a/tests/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
+++ b/tests/JustEat.StatsD.Tests/WhenRegisteringStatsD.cs
@@ -1,9 +1,6 @@
-using System;
 using JustEat.StatsD.EndpointLookups;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/WhenTheTransportThrows.cs
+++ b/tests/JustEat.StatsD.Tests/WhenTheTransportThrows.cs
@@ -1,10 +1,5 @@
-using System;
 using System.Net.Sockets;
 using JustEat.StatsD.Buffered;
-using Shouldly;
-using Xunit;
-
-#pragma warning disable xUnit1026 // Theory methods should use all of their parameters disabled to render test case name
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/WhenUsingBufferBasedPublisher.cs
+++ b/tests/JustEat.StatsD.Tests/WhenUsingBufferBasedPublisher.cs
@@ -1,7 +1,4 @@
-using System;
 using JustEat.StatsD.Buffered;
-using Shouldly;
-using Xunit;
 
 namespace JustEat.StatsD
 {

--- a/tests/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
+++ b/tests/JustEat.StatsD.Tests/WhenUsingUdpTransport.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Net;
-using System.Threading.Tasks;
 using JustEat.StatsD.EndpointLookups;
-using Xunit;
 
 namespace JustEat.StatsD
 {


### PR DESCRIPTION
* Use the .NET 6 SDK and target `net6.0` in the tests.
* Enable NuGet package validation in the SDK.
* Remove .NET Core 2.1 TFM as it is no longer supported, which is fine as v5 will already include breaking changes.
* Update the benchmarks to target .NET6 and run for all three TFMs.
