### PR TITLE
Remove ExcludeByAttribute

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,6 @@
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[Benchmark]*,[*.Tests]*,[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
     <Threshold>85</Threshold>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This is set automatically, so we don't need to specify it.
