### PR TITLE
Add JustEat.StatsD.Diagnostics metrics bridge

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup Condition=" '$(CollectCoverage)' == 'true' ">
-    <CoverletOutput>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', 'coverage'))</CoverletOutput>
+    <CoverletOutput>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', '$(MSBuildProjectName)', 'coverage'))</CoverletOutput>
     <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
     <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
     <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
-    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</ReportGeneratorTargetDirectory>
+    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', '$(MSBuildProjectName)'))</ReportGeneratorTargetDirectory>
     <_MarkdownSummaryPrefix>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_MarkdownSummaryPrefix>
     <_MarkdownSummarySuffix>&lt;/details&gt;</_MarkdownSummarySuffix>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,11 +6,14 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="ReportGenerator" Version="5.5.11" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
@@ -23,9 +26,11 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.StatsD' ">
+  <ItemGroup Condition=" '$(AssemblyName)' != 'JustEat.StatsD' and '$(AssemblyName)' != 'JustEat.StatsD.Diagnostics' ">
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.14" />
     <PackageVersion Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
+    <PackageVersion Update="Microsoft.Extensions.Options" Version="9.0.14" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />

--- a/JustEat.StatsD.sln
+++ b/JustEat.StatsD.sln
@@ -23,11 +23,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Assets", "Assets", "{06BE4D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustEat.StatsD", "src\JustEat.StatsD\JustEat.StatsD.csproj", "{6A338D71-E28B-455A-9E9D-3667EE659542}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustEat.StatsD.Diagnostics", "src\JustEat.StatsD.Diagnostics\JustEat.StatsD.Diagnostics.csproj", "{E71015B5-3F0C-42AD-AB91-45EA284FC461}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{CC2F794C-462F-4545-AEEA-13E34A37528E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustEat.StatsD.Tests", "tests\JustEat.StatsD.Tests\JustEat.StatsD.Tests.csproj", "{5E1B60D3-3F67-4753-8C6C-AC1795978A8D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark", "tests\Benchmark\Benchmark.csproj", "{4C48F92C-8F51-403B-B3DD-281C522C1C7E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JustEat.StatsD.Diagnostics.Tests", "tests\JustEat.StatsD.Diagnostics.Tests\JustEat.StatsD.Diagnostics.Tests.csproj", "{9251A258-E9D2-4690-91ED-A0FF8EBD56CA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{48F0CB2A-4B74-47F2-9234-18147FA389F9}"
 EndProject
@@ -49,14 +53,24 @@ Global
 		{4C48F92C-8F51-403B-B3DD-281C522C1C7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4C48F92C-8F51-403B-B3DD-281C522C1C7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4C48F92C-8F51-403B-B3DD-281C522C1C7E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E71015B5-3F0C-42AD-AB91-45EA284FC461}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E71015B5-3F0C-42AD-AB91-45EA284FC461}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E71015B5-3F0C-42AD-AB91-45EA284FC461}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E71015B5-3F0C-42AD-AB91-45EA284FC461}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9251A258-E9D2-4690-91ED-A0FF8EBD56CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9251A258-E9D2-4690-91ED-A0FF8EBD56CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9251A258-E9D2-4690-91ED-A0FF8EBD56CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9251A258-E9D2-4690-91ED-A0FF8EBD56CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6A338D71-E28B-455A-9E9D-3667EE659542} = {48F0CB2A-4B74-47F2-9234-18147FA389F9}
+		{E71015B5-3F0C-42AD-AB91-45EA284FC461} = {48F0CB2A-4B74-47F2-9234-18147FA389F9}
 		{5E1B60D3-3F67-4753-8C6C-AC1795978A8D} = {CC2F794C-462F-4545-AEEA-13E34A37528E}
 		{4C48F92C-8F51-403B-B3DD-281C522C1C7E} = {CC2F794C-462F-4545-AEEA-13E34A37528E}
+		{9251A258-E9D2-4690-91ED-A0FF8EBD56CA} = {CC2F794C-462F-4545-AEEA-13E34A37528E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {72443623-DCE7-43AB-A24E-1D08807E1F72}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ We use this library within our components to publish [StatsD](https://github.com
 * `netstandard2.0`
 * `net6.0`
 
+`JustEat.StatsD.Diagnostics` is built for these target frameworks:
+
+* `netstandard2.0`
+* `net8.0`
+
 ### Features
 
 * Easy to use.
@@ -30,6 +35,7 @@ We use this library within our components to publish [StatsD](https://github.com
 * Helpers to make it easy to time a delegate such as a `Func<T>` or `Action<T>`, or a code block inside a `using` statement.
 * Send stats over UDP or IP.
 * Send stats to a server by name or IP address.
+* Publish measurements recorded with `System.Diagnostics.Metrics`, including .NET's built-in metrics, using the `JustEat.StatsD.Diagnostics` package.
 
 #### Publishing statistics
 
@@ -267,6 +273,45 @@ In all these cases the function or delegate is supplied with an `IDisposableTime
 #### Credits
 
 The idea of "disposable timers" for using statements is an old one, see for example [this StatsD client](https://github.com/Pereingo/statsd-csharp-client) and [MiniProfiler](https://miniprofiler.com/dotnet/HowTo/ProfileCode).
+
+### System.Diagnostics.Metrics integration
+
+The `JustEat.StatsD.Diagnostics` package publishes measurements recorded with the [`System.Diagnostics.Metrics` APIs](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) to StatsD. This includes the [metrics built into .NET itself](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics), such as those for ASP.NET Core, `HttpClient` and the .NET runtime, as well as any custom metrics recorded with a `Meter`.
+
+The package provides an implementation of [`IMetricsListener`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.diagnostics.metrics.imetricslistener) that is registered with `IMetricsBuilder` and enabled for specific meters and instruments using the standard metrics rules, either in code with `EnableMetrics()` or from the `"Metrics"` section of the application's configuration.
+
+```csharp
+// Register the StatsD publisher and the metrics listener
+services.AddStatsD("metrics_server.mycompany.com");
+services.AddMetrics((metrics) =>
+    metrics.AddStatsD()
+           .EnableMetrics("Microsoft.AspNetCore.Hosting"));
+```
+
+Instruments are published as the following StatsD metrics:
+
+| Instrument | StatsD metric |
+|------------|---------------|
+| `Counter<T>` and `UpDownCounter<T>` | Counter |
+| `Histogram<T>` | Timer. Histograms whose unit is seconds (such as ASP.NET Core's `http.server.request.duration`) are converted to milliseconds. |
+| `Gauge<T>`, `ObservableGauge<T>` and `ObservableUpDownCounter<T>` | Gauge |
+| `ObservableCounter<T>` | Counter. The cumulative totals reported by the instrument are converted to deltas. |
+
+Bucket names default to `{meter-name}.{instrument-name}` and any tags recorded with a measurement are published using the `IStatsDTagsFormatter` configured for the publisher. Observable instruments are polled every 10 seconds by default.
+
+The behaviour can be customized with `StatsDMetricsOptions`:
+
+```csharp
+services.AddMetrics((metrics) =>
+    metrics.AddStatsD((options) =>
+    {
+        options.ObservableInstrumentsPollingInterval = TimeSpan.FromSeconds(30);
+        options.BucketNameProvider = (instrument) => "myservice." + instrument.Name;
+        options.SampleRateProvider = (instrument) => instrument.Name is "hot.path" ? 0.1 : 1;
+    })
+    .EnableMetrics("System.Net.Http")
+    .EnableMetrics("MyCompany.MyService"));
+```
 
 ### How to contribute
 

--- a/build.ps1
+++ b/build.ps1
@@ -13,10 +13,14 @@ $ProgressPreference = "SilentlyContinue"
 $solutionPath = $PSScriptRoot
 $sdkFile = Join-Path $solutionPath "global.json"
 
-$libraryProject = Join-Path $solutionPath "src" "JustEat.StatsD" "JustEat.StatsD.csproj"
+$libraryProjects = @(
+    (Join-Path $solutionPath "src" "JustEat.StatsD" "JustEat.StatsD.csproj"),
+    (Join-Path $solutionPath "src" "JustEat.StatsD.Diagnostics" "JustEat.StatsD.Diagnostics.csproj")
+)
 
 $testProjects = @(
-    (Join-Path $solutionPath "tests" "JustEat.StatsD.Tests" "JustEat.StatsD.Tests.csproj")
+    (Join-Path $solutionPath "tests" "JustEat.StatsD.Tests" "JustEat.StatsD.Tests.csproj"),
+    (Join-Path $solutionPath "tests" "JustEat.StatsD.Diagnostics.Tests" "JustEat.StatsD.Diagnostics.Tests.csproj")
 )
 
 $dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
@@ -110,11 +114,13 @@ function DotNetTest {
 }
 
 
-Write-Host "Packaging library..." -ForegroundColor Green
-DotNetPack $libraryProject
+Write-Host "Packaging libraries..." -ForegroundColor Green
+ForEach ($libraryProject in $libraryProjects) {
+    DotNetPack $libraryProject
+}
 
 Write-Host "Running tests..." -ForegroundColor Green
-Remove-Item -Path (Join-Path $solutionPath "artifacts" "coverage" "coverage.*.json") -Force -ErrorAction SilentlyContinue | Out-Null
+Get-ChildItem -Path (Join-Path $solutionPath "artifacts" "coverage") -Filter "coverage.*.json" -Recurse -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue | Out-Null
 ForEach ($testProject in $testProjects) {
     DotNetTest $testProject
 }

--- a/package-readme.md
+++ b/package-readme.md
@@ -19,6 +19,7 @@ A library to publish [StatsD](https://github.com/etsy/statsd) metrics from .NET 
 * Helpers to make it easy to time a delegate such as a `Func<T>` or `Action<T>`, or a code block inside a `using` statement.
 * Send stats over UDP or IP.
 * Send stats to a server by name or IP address.
+* Publish measurements recorded with `System.Diagnostics.Metrics`, including .NET's built-in metrics, using the `JustEat.StatsD.Diagnostics` package.
 
 ## Feedback
 

--- a/src/JustEat.StatsD.Diagnostics/InstrumentState.cs
+++ b/src/JustEat.StatsD.Diagnostics/InstrumentState.cs
@@ -1,0 +1,242 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace JustEat.StatsD.Diagnostics;
+
+/// <summary>
+/// A class holding the state associated with an enabled instrument. This class cannot be inherited.
+/// </summary>
+internal sealed class InstrumentState
+{
+    private ConcurrentDictionary<string, CumulativeValue>? _values;
+
+    private InstrumentState(
+        StatsDMetricKind kind,
+        string bucket,
+        double scaleFactor,
+        double sampleRate,
+        bool accumulatesResidual,
+        KeyValuePair<string, object?>[]? instrumentTags)
+    {
+        Kind = kind;
+        Bucket = bucket;
+        ScaleFactor = scaleFactor;
+        SampleRate = sampleRate;
+        AccumulatesResidual = accumulatesResidual;
+        InstrumentTags = instrumentTags;
+
+        if (kind == StatsDMetricKind.CumulativeCounter || accumulatesResidual)
+        {
+            _values = new ConcurrentDictionary<string, CumulativeValue>(concurrencyLevel: 1, capacity: 1, StringComparer.Ordinal);
+        }
+    }
+
+    internal StatsDMetricKind Kind { get; }
+
+    internal string Bucket { get; }
+
+    internal double ScaleFactor { get; }
+
+    internal double SampleRate { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the (non-cumulative) counter accumulates the fractional
+    /// part of its deltas so that fractional measurements are not lost to integer truncation.
+    /// </summary>
+    internal bool AccumulatesResidual { get; }
+
+    /// <summary>
+    /// Gets the tags associated with the instrument itself, or <see langword="null"/> if it has none.
+    /// </summary>
+    internal KeyValuePair<string, object?>[]? InstrumentTags { get; }
+
+    internal static InstrumentState? TryCreate(Instrument instrument, StatsDMetricsOptions options)
+    {
+        var type = instrument.GetType();
+        var genericType = type.IsGenericType ? type.GetGenericTypeDefinition() : null;
+
+        StatsDMetricKind kind;
+        double scaleFactor = 1;
+        bool accumulatesResidual = false;
+
+        if (genericType == typeof(Counter<>) || genericType == typeof(UpDownCounter<>))
+        {
+            // Both instruments report deltas, which is exactly what a StatsD counter expects.
+            kind = StatsDMetricKind.Counter;
+
+            // StatsD counters are integer-valued, so a counter of a floating-point type must
+            // accumulate the fractional part of its deltas rather than round each one in
+            // isolation, which would otherwise silently drop deltas smaller than 0.5.
+            var valueType = type.GetGenericArguments()[0];
+            accumulatesResidual = valueType == typeof(double) || valueType == typeof(float) || valueType == typeof(decimal);
+        }
+        else if (genericType == typeof(Histogram<>))
+        {
+            // StatsD timers are the only aggregating StatsD metric, so all
+            // histograms are published as timers. Durations that follow the
+            // OpenTelemetry conventions are recorded in seconds, whereas
+            // StatsD timers are conventionally milliseconds.
+            kind = StatsDMetricKind.Timing;
+
+            if (options.ConvertSecondsToMilliseconds && string.Equals(instrument.Unit, "s", StringComparison.Ordinal))
+            {
+                scaleFactor = 1000;
+            }
+        }
+        else if (genericType == typeof(Gauge<>) || genericType == typeof(ObservableGauge<>) || genericType == typeof(ObservableUpDownCounter<>))
+        {
+            // An ObservableUpDownCounter reports its current total (e.g. the length
+            // of a queue), which has the semantics of a StatsD gauge, not a counter.
+            kind = StatsDMetricKind.Gauge;
+        }
+        else if (genericType == typeof(ObservableCounter<>))
+        {
+            // ObservableCounter reports cumulative totals, which must be
+            // converted to deltas before being published as StatsD counters.
+            kind = StatsDMetricKind.CumulativeCounter;
+        }
+        else
+        {
+            return null;
+        }
+
+        string bucket = options.BucketNameProvider?.Invoke(instrument) ?? DefaultBucketName(instrument);
+
+        if (string.IsNullOrEmpty(bucket))
+        {
+            return null;
+        }
+
+        double sampleRate = options.SampleRateProvider?.Invoke(instrument) ?? 1;
+
+        // Tags supplied when the instrument was created are not delivered in the measurement
+        // callback, so capture them here to merge with the per-measurement tags when publishing.
+        var instrumentTags = instrument.Tags?.ToArray();
+
+        if (instrumentTags is { Length: 0 })
+        {
+            instrumentTags = null;
+        }
+
+        return new InstrumentState(kind, bucket, scaleFactor, sampleRate, accumulatesResidual, instrumentTags);
+    }
+
+    /// <summary>
+    /// Accumulates a counter delta, returning the whole-number part to publish and carrying the
+    /// fractional remainder over to the next measurement, keyed by the measurement's tags.
+    /// </summary>
+    internal long NextCounterDelta(string tagsKey, double delta)
+    {
+        var state = _values!.GetOrAdd(tagsKey, static (_) => new CumulativeValue());
+
+        lock (state)
+        {
+            state.Residual += delta;
+
+            long result = (long)state.Residual;
+            state.Residual -= result;
+
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Converts a cumulative total into the delta to publish, keyed by the measurement's tags.
+    /// </summary>
+    internal long NextDelta(string tagsKey, double value)
+    {
+        var cumulative = _values!.GetOrAdd(tagsKey, static (_) => new CumulativeValue());
+
+        lock (cumulative)
+        {
+            double delta = cumulative.HasValue ? value - cumulative.Value : value;
+
+            if (delta < 0)
+            {
+                // The counter appears to have been reset, so publish the new total.
+                delta = value;
+            }
+
+            cumulative.Value = value;
+            cumulative.HasValue = true;
+
+            // Accumulate any fractional part so that non-integral
+            // totals do not drift as deltas are truncated.
+            cumulative.Residual += delta;
+
+            long result = (long)cumulative.Residual;
+            cumulative.Residual -= result;
+
+            return result;
+        }
+    }
+
+    internal static string TagsKey(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        if (tags.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+
+        foreach (var tag in tags)
+        {
+            builder.Append(tag.Key)
+                   .Append('\u001e')
+                   .Append(FormatTagValue(tag.Value))
+                   .Append('\u001f');
+        }
+
+        return builder.ToString();
+    }
+
+    internal static string? FormatTagValue(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string text => text,
+            bool flag => flag ? "true" : "false",
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString(),
+        };
+    }
+
+    private static string DefaultBucketName(Instrument instrument)
+    {
+        string name = instrument.Meter.Name.Length > 0 ?
+            instrument.Meter.Name + "." + instrument.Name :
+            instrument.Name;
+
+        return Sanitize(name);
+    }
+
+    private static string Sanitize(string bucket)
+    {
+        char[]? sanitized = null;
+
+        for (int i = 0; i < bucket.Length; i++)
+        {
+            char ch = bucket[i];
+
+            if (ch is ':' or '|' or '@' or '#' or '\n' || char.IsWhiteSpace(ch))
+            {
+                sanitized ??= bucket.ToCharArray();
+                sanitized[i] = '_';
+            }
+        }
+
+        return sanitized is null ? bucket : new string(sanitized);
+    }
+
+    private sealed class CumulativeValue
+    {
+        internal double Value;
+        internal double Residual;
+        internal bool HasValue;
+    }
+}

--- a/src/JustEat.StatsD.Diagnostics/InstrumentState.cs
+++ b/src/JustEat.StatsD.Diagnostics/InstrumentState.cs
@@ -159,6 +159,35 @@ internal sealed class InstrumentState
     }
 
     /// <summary>
+    /// Converts a cumulative integral total into the delta to publish, keyed by the measurement's tags.
+    /// </summary>
+    /// <remarks>
+    /// The total is tracked as a <see cref="long"/> rather than a <see cref="double"/> so that a
+    /// counter which grows beyond the range that a <see cref="double"/> can represent exactly
+    /// (2^53) continues to produce accurate deltas rather than quantized ones.
+    /// </remarks>
+    internal long NextDelta(string tagsKey, long value)
+    {
+        var cumulative = _values!.GetOrAdd(tagsKey, static (_) => new CumulativeValue());
+
+        lock (cumulative)
+        {
+            long delta = cumulative.HasValue ? value - cumulative.IntegralValue : value;
+
+            if (delta < 0)
+            {
+                // The counter appears to have been reset, so publish the new total.
+                delta = value;
+            }
+
+            cumulative.IntegralValue = value;
+            cumulative.HasValue = true;
+
+            return delta;
+        }
+    }
+
+    /// <summary>
     /// Converts a cumulative total into the delta to publish, keyed by the measurement's tags.
     /// </summary>
     internal long NextDelta(string tagsKey, double value)
@@ -304,9 +333,12 @@ internal sealed class InstrumentState
         return sanitized is null ? bucket : new string(sanitized);
     }
 
+    // An instrument's measurements are always of a single type, so only the value
+    // field matching that type's code path is ever used for a given instrument.
     private sealed class CumulativeValue
     {
         internal double Value;
+        internal long IntegralValue;
         internal double Residual;
         internal bool HasValue;
     }

--- a/src/JustEat.StatsD.Diagnostics/InstrumentState.cs
+++ b/src/JustEat.StatsD.Diagnostics/InstrumentState.cs
@@ -11,7 +11,11 @@ namespace JustEat.StatsD.Diagnostics;
 /// </summary>
 internal sealed class InstrumentState
 {
-    private ConcurrentDictionary<string, CumulativeValue>? _values;
+    // The maximum number of measurement tags for which the order used
+    // to build a lookup key is computed without allocating an array.
+    private const int MaxStackAllocTags = 16;
+
+    private readonly ConcurrentDictionary<string, CumulativeValue>? _values;
 
     private InstrumentState(
         StatsDMetricKind kind,
@@ -110,7 +114,18 @@ internal sealed class InstrumentState
             return null;
         }
 
+        // Sanitized regardless of where the name came from so that a custom bucket name
+        // cannot contain characters that the StatsD protocol treats as separators.
+        bucket = Sanitize(bucket);
+
         double sampleRate = options.SampleRateProvider?.Invoke(instrument) ?? 1;
+
+        // A sample rate outside the range that StatsD supports would cause the
+        // instrument's measurements to be silently discarded, so ignore it.
+        if (double.IsNaN(sampleRate) || sampleRate <= 0 || sampleRate > 1)
+        {
+            sampleRate = 1;
+        }
 
         // Tags supplied when the instrument was created are not delivered in the measurement
         // callback, so capture them here to merge with the per-measurement tags when publishing.
@@ -183,15 +198,73 @@ internal sealed class InstrumentState
 
         var builder = new StringBuilder();
 
-        foreach (var tag in tags)
+        if (tags.Length == 1)
         {
-            builder.Append(tag.Key)
-                   .Append('\u001e')
-                   .Append(FormatTagValue(tag.Value))
-                   .Append('\u001f');
+            return AppendTag(builder, tags[0]).ToString();
+        }
+
+        // The same logical set of tags can be recorded with the tags in a different order by
+        // different call sites, so they are ordered by name to prevent such measurements being
+        // tracked as if they belonged to two different time series.
+        Span<int> order = stackalloc int[MaxStackAllocTags];
+
+        if (tags.Length > MaxStackAllocTags)
+        {
+            order = new int[tags.Length];
+        }
+        else
+        {
+            order = order.Slice(0, tags.Length);
+        }
+
+        for (int i = 0; i < order.Length; i++)
+        {
+            order[i] = i;
+        }
+
+        // An insertion sort is used as instruments have few tags in practice.
+        for (int i = 1; i < order.Length; i++)
+        {
+            int current = order[i];
+            int j = i - 1;
+
+            while (j > -1 && string.CompareOrdinal(tags[order[j]].Key, tags[current].Key) > 0)
+            {
+                order[j + 1] = order[j];
+                j--;
+            }
+
+            order[j + 1] = current;
+        }
+
+        foreach (int index in order)
+        {
+            AppendTag(builder, tags[index]);
         }
 
         return builder.ToString();
+    }
+
+    private static StringBuilder AppendTag(StringBuilder builder, KeyValuePair<string, object?> tag)
+    {
+        string? value = FormatTagValue(tag.Value);
+
+        builder.Append(tag.Key)
+               .Append('\u001e');
+
+        // A null tag value is marked explicitly so that it does not produce
+        // the same key as a tag whose value is an empty string.
+        if (value is null)
+        {
+            builder.Append('\u0000');
+        }
+        else
+        {
+            builder.Append('\u0001')
+                   .Append(value);
+        }
+
+        return builder.Append('\u001f');
     }
 
     internal static string? FormatTagValue(object? value)
@@ -208,11 +281,9 @@ internal sealed class InstrumentState
 
     private static string DefaultBucketName(Instrument instrument)
     {
-        string name = instrument.Meter.Name.Length > 0 ?
+        return instrument.Meter.Name.Length > 0 ?
             instrument.Meter.Name + "." + instrument.Name :
             instrument.Name;
-
-        return Sanitize(name);
     }
 
     private static string Sanitize(string bucket)

--- a/src/JustEat.StatsD.Diagnostics/JustEat.StatsD.Diagnostics.csproj
+++ b/src/JustEat.StatsD.Diagnostics/JustEat.StatsD.Diagnostics.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>A .NET library for publishing System.Diagnostics.Metrics measurements to StatsD.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
+    <LangVersion>12</LangVersion>
+    <OutputType>Library</OutputType>
+    <PackageId>JustEat.StatsD.Diagnostics</PackageId>
+    <RootNamespace>JustEat.StatsD.Diagnostics</RootNamespace>
+    <Summary>A .NET library for publishing System.Diagnostics.Metrics measurements to StatsD.</Summary>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\JustEat.StatsD\JustEat.StatsD.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <PropertyGroup Condition=" $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) ">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+</Project>

--- a/src/JustEat.StatsD.Diagnostics/PublicAPI.Shipped.txt
+++ b/src/JustEat.StatsD.Diagnostics/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/JustEat.StatsD.Diagnostics/PublicAPI.Unshipped.txt
+++ b/src/JustEat.StatsD.Diagnostics/PublicAPI.Unshipped.txt
@@ -1,0 +1,23 @@
+#nullable enable
+const JustEat.StatsD.Diagnostics.StatsDMetricsListener.ListenerName = "JustEat.StatsD" -> string!
+JustEat.StatsD.Diagnostics.StatsDMetricsListener
+JustEat.StatsD.Diagnostics.StatsDMetricsListener.Dispose() -> void
+JustEat.StatsD.Diagnostics.StatsDMetricsListener.GetMeasurementHandlers() -> Microsoft.Extensions.Diagnostics.Metrics.MeasurementHandlers!
+JustEat.StatsD.Diagnostics.StatsDMetricsListener.Initialize(Microsoft.Extensions.Diagnostics.Metrics.IObservableInstrumentsSource! source) -> void
+JustEat.StatsD.Diagnostics.StatsDMetricsListener.InstrumentPublished(System.Diagnostics.Metrics.Instrument! instrument, out object? userState) -> bool
+JustEat.StatsD.Diagnostics.StatsDMetricsListener.MeasurementsCompleted(System.Diagnostics.Metrics.Instrument! instrument, object? userState) -> void
+JustEat.StatsD.Diagnostics.StatsDMetricsListener.Name.get -> string!
+JustEat.StatsD.Diagnostics.StatsDMetricsListener.StatsDMetricsListener(JustEat.StatsD.IStatsDPublisherWithTags! publisher, Microsoft.Extensions.Options.IOptions<JustEat.StatsD.Diagnostics.StatsDMetricsOptions!>! options) -> void
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.BucketNameProvider.get -> System.Func<System.Diagnostics.Metrics.Instrument!, string!>?
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.BucketNameProvider.set -> void
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.ConvertSecondsToMilliseconds.get -> bool
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.ConvertSecondsToMilliseconds.set -> void
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.ObservableInstrumentsPollingInterval.get -> System.TimeSpan
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.ObservableInstrumentsPollingInterval.set -> void
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.SampleRateProvider.get -> System.Func<System.Diagnostics.Metrics.Instrument!, double>?
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.SampleRateProvider.set -> void
+JustEat.StatsD.Diagnostics.StatsDMetricsOptions.StatsDMetricsOptions() -> void
+JustEat.StatsD.StatsDMetricsBuilderExtensions
+static JustEat.StatsD.StatsDMetricsBuilderExtensions.AddStatsD(this Microsoft.Extensions.Diagnostics.Metrics.IMetricsBuilder! builder) -> Microsoft.Extensions.Diagnostics.Metrics.IMetricsBuilder!
+static JustEat.StatsD.StatsDMetricsBuilderExtensions.AddStatsD(this Microsoft.Extensions.Diagnostics.Metrics.IMetricsBuilder! builder, System.Action<JustEat.StatsD.Diagnostics.StatsDMetricsOptions!>? configureMetrics) -> Microsoft.Extensions.Diagnostics.Metrics.IMetricsBuilder!

--- a/src/JustEat.StatsD.Diagnostics/StatsDMetricKind.cs
+++ b/src/JustEat.StatsD.Diagnostics/StatsDMetricKind.cs
@@ -1,0 +1,27 @@
+namespace JustEat.StatsD.Diagnostics;
+
+/// <summary>
+/// An enumeration of the kinds of StatsD metric an instrument's measurements are published as.
+/// </summary>
+internal enum StatsDMetricKind
+{
+    /// <summary>
+    /// The measurements are deltas published as a StatsD counter.
+    /// </summary>
+    Counter,
+
+    /// <summary>
+    /// The measurements are cumulative totals converted to deltas and published as a StatsD counter.
+    /// </summary>
+    CumulativeCounter,
+
+    /// <summary>
+    /// The measurements are published as a StatsD gauge.
+    /// </summary>
+    Gauge,
+
+    /// <summary>
+    /// The measurements are published as a StatsD timer.
+    /// </summary>
+    Timing,
+}

--- a/src/JustEat.StatsD.Diagnostics/StatsDMetricsBuilderExtensions.cs
+++ b/src/JustEat.StatsD.Diagnostics/StatsDMetricsBuilderExtensions.cs
@@ -1,0 +1,66 @@
+using JustEat.StatsD.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
+
+namespace JustEat.StatsD;
+
+/// <summary>
+/// A class containing extension methods for registering StatsD with <see cref="IMetricsBuilder"/>. This class cannot be inherited.
+/// </summary>
+public static class StatsDMetricsBuilderExtensions
+{
+    /// <summary>
+    /// Adds a listener to the specified <see cref="IMetricsBuilder"/> that publishes
+    /// measurements from enabled instruments to StatsD.
+    /// </summary>
+    /// <param name="builder">The <see cref="IMetricsBuilder"/> to add the StatsD listener to.</param>
+    /// <returns>
+    /// The value specified by <paramref name="builder"/>.
+    /// </returns>
+    /// <remarks>
+    /// An implementation of <see cref="IStatsDPublisherWithTags"/> must be registered with
+    /// the service collection, such as by using <see cref="StatsDServiceCollectionExtensions"/>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> is <see langword="null"/>.
+    /// </exception>
+    public static IMetricsBuilder AddStatsD(this IMetricsBuilder builder)
+        => AddStatsD(builder, configureMetrics: null);
+
+    /// <summary>
+    /// Adds a listener to the specified <see cref="IMetricsBuilder"/> that publishes
+    /// measurements from enabled instruments to StatsD.
+    /// </summary>
+    /// <param name="builder">The <see cref="IMetricsBuilder"/> to add the StatsD listener to.</param>
+    /// <param name="configureMetrics">An optional delegate to use to configure the <see cref="StatsDMetricsOptions"/> to use.</param>
+    /// <returns>
+    /// The value specified by <paramref name="builder"/>.
+    /// </returns>
+    /// <remarks>
+    /// An implementation of <see cref="IStatsDPublisherWithTags"/> must be registered with
+    /// the service collection, such as by using <see cref="StatsDServiceCollectionExtensions"/>.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder"/> is <see langword="null"/>.
+    /// </exception>
+    public static IMetricsBuilder AddStatsD(this IMetricsBuilder builder, Action<StatsDMetricsOptions>? configureMetrics)
+    {
+#if NET
+        ArgumentNullException.ThrowIfNull(builder);
+#else
+        if (builder == null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+#endif
+
+        builder.Services.AddOptions();
+
+        if (configureMetrics != null)
+        {
+            builder.Services.Configure(configureMetrics);
+        }
+
+        return builder.AddListener<StatsDMetricsListener>();
+    }
+}

--- a/src/JustEat.StatsD.Diagnostics/StatsDMetricsListener.cs
+++ b/src/JustEat.StatsD.Diagnostics/StatsDMetricsListener.cs
@@ -1,0 +1,237 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Options;
+
+namespace JustEat.StatsD.Diagnostics;
+
+/// <summary>
+/// A class representing an implementation of <see cref="IMetricsListener"/> that publishes
+/// measurements recorded by <see cref="System.Diagnostics.Metrics"/> instruments to StatsD.
+/// This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Instruments are published as follows: <see cref="Counter{T}"/> and <see cref="UpDownCounter{T}"/>
+/// measurements are published as StatsD counters; <see cref="Histogram{T}"/> measurements are
+/// published as StatsD timers; <see cref="Gauge{T}"/>, <see cref="ObservableGauge{T}"/> and
+/// <see cref="ObservableUpDownCounter{T}"/> measurements are published as StatsD gauges; and
+/// <see cref="ObservableCounter{T}"/> measurements are converted from cumulative totals to
+/// deltas and published as StatsD counters.
+/// </para>
+/// <para>
+/// Observable instruments are polled at the interval specified by
+/// <see cref="StatsDMetricsOptions.ObservableInstrumentsPollingInterval"/>.
+/// </para>
+/// </remarks>
+public sealed class StatsDMetricsListener : IMetricsListener, IDisposable
+{
+    /// <summary>
+    /// The name of the listener used to identify it in metrics configuration rules.
+    /// </summary>
+    public const string ListenerName = "JustEat.StatsD";
+
+    private readonly IStatsDPublisherWithTags _publisher;
+    private readonly StatsDMetricsOptions _options;
+    private readonly MeasurementHandlers _handlers;
+    private readonly object _syncRoot = new();
+
+    private IObservableInstrumentsSource? _source;
+    private Timer? _timer;
+    private bool _hasObservableInstruments;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StatsDMetricsListener"/> class.
+    /// </summary>
+    /// <param name="publisher">The <see cref="IStatsDPublisherWithTags"/> to publish measurements with.</param>
+    /// <param name="options">The <see cref="StatsDMetricsOptions"/> to use.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="publisher"/> or <paramref name="options"/> is <see langword="null"/>.
+    /// </exception>
+    public StatsDMetricsListener(IStatsDPublisherWithTags publisher, IOptions<StatsDMetricsOptions> options)
+    {
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+
+        _handlers = new MeasurementHandlers()
+        {
+            ByteHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
+            ShortHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
+            IntHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
+            LongHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
+            FloatHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
+            DoubleHandler = Record,
+            DecimalHandler = (instrument, value, tags, state) => Record(instrument, (double)value, tags, state),
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => ListenerName;
+
+    /// <inheritdoc />
+    public MeasurementHandlers GetMeasurementHandlers() => _handlers;
+
+    /// <inheritdoc />
+    public bool InstrumentPublished(Instrument instrument, out object? userState)
+    {
+        userState = InstrumentState.TryCreate(instrument, _options);
+
+        if (userState is null)
+        {
+            return false;
+        }
+
+        if (instrument.IsObservable)
+        {
+            lock (_syncRoot)
+            {
+                _hasObservableInstruments = true;
+                EnsureTimer();
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public void MeasurementsCompleted(Instrument instrument, object? userState)
+    {
+        // There is no per-instrument state to release beyond the user state itself.
+    }
+
+    /// <inheritdoc />
+    public void Initialize(IObservableInstrumentsSource source)
+    {
+        lock (_syncRoot)
+        {
+            _source = source;
+            EnsureTimer();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        lock (_syncRoot)
+        {
+            _disposed = true;
+            _timer?.Dispose();
+            _timer = null;
+        }
+    }
+
+    private void EnsureTimer()
+    {
+        if (_disposed || _timer is not null || _source is null || !_hasObservableInstruments)
+        {
+            return;
+        }
+
+        var interval = _options.ObservableInstrumentsPollingInterval;
+
+        if (interval <= TimeSpan.Zero)
+        {
+            interval = TimeSpan.FromSeconds(10);
+        }
+
+        _timer = new Timer(static (state) => ((StatsDMetricsListener)state!).PollObservableInstruments(), this, interval, interval);
+    }
+
+#pragma warning disable CA1031
+    private void PollObservableInstruments()
+    {
+        try
+        {
+            _source?.RecordObservableInstruments();
+        }
+        catch (Exception)
+        {
+            // Swallow exceptions thrown by observable instrument callbacks so
+            // that they do not terminate the process from the timer thread.
+        }
+    }
+#pragma warning restore CA1031
+
+    private void Record(Instrument instrument, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+    {
+        if (state is not InstrumentState instrumentState)
+        {
+            return;
+        }
+
+        var statsDTags = CreateTags(instrumentState, tags);
+
+        switch (instrumentState.Kind)
+        {
+            case StatsDMetricKind.Counter:
+                if (instrumentState.AccumulatesResidual)
+                {
+                    long increment = instrumentState.NextCounterDelta(InstrumentState.TagsKey(tags), value);
+
+                    if (increment != 0)
+                    {
+                        _publisher.Increment(increment, instrumentState.SampleRate, instrumentState.Bucket, statsDTags);
+                    }
+                }
+                else
+                {
+                    _publisher.Increment(RoundToLong(value), instrumentState.SampleRate, instrumentState.Bucket, statsDTags);
+                }
+
+                break;
+
+            case StatsDMetricKind.CumulativeCounter:
+                long delta = instrumentState.NextDelta(InstrumentState.TagsKey(tags), value);
+
+                if (delta != 0)
+                {
+                    _publisher.Increment(delta, instrumentState.SampleRate, instrumentState.Bucket, statsDTags);
+                }
+
+                break;
+
+            case StatsDMetricKind.Gauge:
+                _publisher.Gauge(value, instrumentState.Bucket, statsDTags);
+                break;
+
+            case StatsDMetricKind.Timing:
+                _publisher.Timing(RoundToLong(value * instrumentState.ScaleFactor), instrumentState.SampleRate, instrumentState.Bucket, statsDTags);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    private static long RoundToLong(double value)
+        => (long)Math.Round(value, MidpointRounding.AwayFromZero);
+
+    private static Dictionary<string, string?>? CreateTags(InstrumentState state, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    {
+        var instrumentTags = state.InstrumentTags;
+
+        if (tags.IsEmpty && instrumentTags is null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, string?>(tags.Length + (instrumentTags?.Length ?? 0), StringComparer.Ordinal);
+
+        // Apply the instrument's own tags first so that a measurement tag of the same
+        // name takes precedence over an instrument tag, matching OpenTelemetry semantics.
+        if (instrumentTags is not null)
+        {
+            foreach (var tag in instrumentTags)
+            {
+                result[tag.Key] = InstrumentState.FormatTagValue(tag.Value);
+            }
+        }
+
+        foreach (var tag in tags)
+        {
+            result[tag.Key] = InstrumentState.FormatTagValue(tag.Value);
+        }
+
+        return result;
+    }
+}

--- a/src/JustEat.StatsD.Diagnostics/StatsDMetricsListener.cs
+++ b/src/JustEat.StatsD.Diagnostics/StatsDMetricsListener.cs
@@ -53,14 +53,17 @@ public sealed class StatsDMetricsListener : IMetricsListener, IDisposable
         _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
 
+        // Integral measurements are kept on a long code path so that values that cannot be
+        // represented exactly by a double (such as the cumulative byte counters reported by
+        // the built-in .NET meters in a long-running process) are published without loss.
         _handlers = new MeasurementHandlers()
         {
             ByteHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
             ShortHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
             IntHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
             LongHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
-            FloatHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
-            DoubleHandler = Record,
+            FloatHandler = (instrument, value, tags, state) => Record(instrument, (double)value, tags, state),
+            DoubleHandler = (instrument, value, tags, state) => Record(instrument, value, tags, state),
             DecimalHandler = (instrument, value, tags, state) => Record(instrument, (double)value, tags, state),
         };
     }
@@ -152,6 +155,47 @@ public sealed class StatsDMetricsListener : IMetricsListener, IDisposable
     }
 #pragma warning restore CA1031
 
+    private void Record(Instrument instrument, long value, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
+    {
+        if (state is not InstrumentState instrumentState)
+        {
+            return;
+        }
+
+        var statsDTags = CreateTags(instrumentState, tags);
+
+        switch (instrumentState.Kind)
+        {
+            case StatsDMetricKind.Counter:
+                // An integral counter reports whole deltas, so there is no residual to accumulate.
+                _publisher.Increment(value, instrumentState.SampleRate, instrumentState.Bucket, statsDTags);
+                break;
+
+            case StatsDMetricKind.CumulativeCounter:
+                long delta = instrumentState.NextDelta(InstrumentState.TagsKey(tags), value);
+
+                if (delta != 0)
+                {
+                    _publisher.Increment(delta, instrumentState.SampleRate, instrumentState.Bucket, statsDTags);
+                }
+
+                break;
+
+            case StatsDMetricKind.Gauge:
+                // IStatsDPublisherWithTags.Gauge() accepts a double, so an integral
+                // measurement cannot be published any more precisely than this.
+                _publisher.Gauge(value, instrumentState.Bucket, statsDTags);
+                break;
+
+            case StatsDMetricKind.Timing:
+                _publisher.Timing(Scale(value, instrumentState.ScaleFactor), instrumentState.SampleRate, instrumentState.Bucket, statsDTags);
+                break;
+
+            default:
+                break;
+        }
+    }
+
     private void Record(Instrument instrument, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags, object? state)
     {
         if (state is not InstrumentState instrumentState)
@@ -205,6 +249,11 @@ public sealed class StatsDMetricsListener : IMetricsListener, IDisposable
 
     private static long RoundToLong(double value)
         => (long)Math.Round(value, MidpointRounding.AwayFromZero);
+
+    // An unscaled integral timing is published as-is so that it does not lose
+    // precision by being converted to a double just to be multiplied by one.
+    private static long Scale(long value, double scaleFactor)
+        => scaleFactor == 1 ? value : RoundToLong(value * scaleFactor);
 
     private static Dictionary<string, string?>? CreateTags(InstrumentState state, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {

--- a/src/JustEat.StatsD.Diagnostics/StatsDMetricsOptions.cs
+++ b/src/JustEat.StatsD.Diagnostics/StatsDMetricsOptions.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.Metrics;
+
+namespace JustEat.StatsD.Diagnostics;
+
+/// <summary>
+/// A class representing the options to use for publishing <see cref="System.Diagnostics.Metrics"/> measurements to StatsD.
+/// </summary>
+public sealed class StatsDMetricsOptions
+{
+    /// <summary>
+    /// Gets or sets the interval at which observable instruments are polled for measurements.
+    /// </summary>
+    /// <remarks>
+    /// The default value is 10 seconds.
+    /// </remarks>
+    public TimeSpan ObservableInstrumentsPollingInterval { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether histogram measurements recorded in seconds
+    /// (instruments whose unit is <c>s</c>) are converted to milliseconds before being
+    /// published as StatsD timers.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <see langword="true"/>. OpenTelemetry semantic conventions record
+    /// durations in seconds (for example the built-in ASP.NET Core <c>http.server.request.duration</c>
+    /// histogram), whereas StatsD timers are conventionally measured in milliseconds.
+    /// </remarks>
+    public bool ConvertSecondsToMilliseconds { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets an optional delegate to use to generate the StatsD bucket name for an instrument.
+    /// </summary>
+    /// <remarks>
+    /// If <see langword="null"/>, the bucket name is <c>{meter-name}.{instrument-name}</c>.
+    /// </remarks>
+    public Func<Instrument, string>? BucketNameProvider { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional delegate to use to determine the sample rate for an instrument.
+    /// </summary>
+    /// <remarks>
+    /// If <see langword="null"/>, all measurements are published.
+    /// </remarks>
+    public Func<Instrument, double>? SampleRateProvider { get; set; }
+}

--- a/tests/JustEat.StatsD.Diagnostics.Tests/FakeStatsDPublisher.cs
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/FakeStatsDPublisher.cs
@@ -1,0 +1,19 @@
+using System.Collections.Concurrent;
+
+namespace JustEat.StatsD.Diagnostics;
+
+internal sealed class FakeStatsDPublisher : IStatsDPublisherWithTags
+{
+    internal sealed record Metric(string Kind, double Value, double SampleRate, string Bucket, Dictionary<string, string?>? Tags);
+
+    internal ConcurrentQueue<Metric> Metrics { get; } = new();
+
+    public void Increment(long value, double sampleRate, string bucket, Dictionary<string, string?>? tags)
+        => Metrics.Enqueue(new("counter", value, sampleRate, bucket, tags));
+
+    public void Gauge(double value, string bucket, Dictionary<string, string?>? tags)
+        => Metrics.Enqueue(new("gauge", value, 1, bucket, tags));
+
+    public void Timing(long duration, double sampleRate, string bucket, Dictionary<string, string?>? tags)
+        => Metrics.Enqueue(new("timing", duration, sampleRate, bucket, tags));
+}

--- a/tests/JustEat.StatsD.Diagnostics.Tests/FakeStatsDPublisher.cs
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/FakeStatsDPublisher.cs
@@ -4,16 +4,23 @@ namespace JustEat.StatsD.Diagnostics;
 
 internal sealed class FakeStatsDPublisher : IStatsDPublisherWithTags
 {
-    internal sealed record Metric(string Kind, double Value, double SampleRate, string Bucket, Dictionary<string, string?>? Tags);
+    internal sealed record Metric(string Kind, double Value, double SampleRate, string Bucket, Dictionary<string, string?>? Tags)
+    {
+        /// <summary>
+        /// Gets the value published for a counter or a timing, which cannot always be
+        /// represented exactly by <see cref="Value"/>, or <see langword="null"/> for a gauge.
+        /// </summary>
+        internal long? IntegralValue { get; init; }
+    }
 
     internal ConcurrentQueue<Metric> Metrics { get; } = new();
 
     public void Increment(long value, double sampleRate, string bucket, Dictionary<string, string?>? tags)
-        => Metrics.Enqueue(new("counter", value, sampleRate, bucket, tags));
+        => Metrics.Enqueue(new("counter", value, sampleRate, bucket, tags) { IntegralValue = value });
 
     public void Gauge(double value, string bucket, Dictionary<string, string?>? tags)
         => Metrics.Enqueue(new("gauge", value, 1, bucket, tags));
 
     public void Timing(long duration, double sampleRate, string bucket, Dictionary<string, string?>? tags)
-        => Metrics.Enqueue(new("timing", duration, sampleRate, bucket, tags));
+        => Metrics.Enqueue(new("timing", duration, sampleRate, bucket, tags) { IntegralValue = duration });
 }

--- a/tests/JustEat.StatsD.Diagnostics.Tests/JustEat.StatsD.Diagnostics.Tests.csproj
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/JustEat.StatsD.Diagnostics.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Include>[JustEat.StatsD.Diagnostics]*</Include>
+    <NoWarn>$(NoWarn);CA1014;CA1002;CA1861;CA1707;CA1711;CA2007</NoWarn>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>JustEat.StatsD.Diagnostics</RootNamespace>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\JustEat.StatsD.Diagnostics\JustEat.StatsD.Diagnostics.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Shouldly" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/JustEat.StatsD.Diagnostics.Tests/StatsDMetricsListenerTests.cs
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/StatsDMetricsListenerTests.cs
@@ -1,0 +1,502 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Options;
+
+namespace JustEat.StatsD.Diagnostics;
+
+public static class StatsDMetricsListenerTests
+{
+    [Fact]
+    public static void Constructor_Validates_Arguments()
+    {
+        // Arrange
+        var publisher = new FakeStatsDPublisher();
+        var options = Options.Create(new StatsDMetricsOptions());
+
+        // Act and Assert
+        Should.Throw<ArgumentNullException>(() => new StatsDMetricsListener(null!, options)).ParamName.ShouldBe("publisher");
+        Should.Throw<ArgumentNullException>(() => new StatsDMetricsListener(publisher, null!)).ParamName.ShouldBe("options");
+    }
+
+    [Fact]
+    public static void Listener_Has_Expected_Name()
+    {
+        // Arrange
+        using var listener = CreateListener(out _);
+
+        // Assert
+        listener.Name.ShouldBe("JustEat.StatsD");
+        StatsDMetricsListener.ListenerName.ShouldBe("JustEat.StatsD");
+    }
+
+    [Fact]
+    public static void Counter_Measurements_Are_Published_As_Counters()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.Counters");
+        var counter = meter.CreateCounter<int>("requests");
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().IntHandler!(counter, 5, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("counter");
+        metric.Value.ShouldBe(5);
+        metric.SampleRate.ShouldBe(1);
+        metric.Bucket.ShouldBe("TestMeter.Counters.requests");
+        metric.Tags.ShouldBeNull();
+    }
+
+    [Fact]
+    public static void UpDownCounter_Measurements_Are_Published_As_Counters()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.UpDown");
+        var counter = meter.CreateUpDownCounter<long>("connections");
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().LongHandler!(counter, -2, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("counter");
+        metric.Value.ShouldBe(-2);
+    }
+
+    [Fact]
+    public static void Histogram_Measurements_In_Seconds_Are_Published_As_Timers_In_Milliseconds()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.Histograms");
+        var histogram = meter.CreateHistogram<double>("http.server.request.duration", unit: "s");
+
+        // Act
+        listener.InstrumentPublished(histogram, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().DoubleHandler!(histogram, 1.234, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("timing");
+        metric.Value.ShouldBe(1234);
+        metric.Bucket.ShouldBe("TestMeter.Histograms.http.server.request.duration");
+    }
+
+    [Fact]
+    public static void Histogram_Measurements_Not_In_Seconds_Are_Not_Converted()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.HistogramsMs");
+        var histogram = meter.CreateHistogram<double>("duration", unit: "ms");
+
+        // Act
+        listener.InstrumentPublished(histogram, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().DoubleHandler!(histogram, 42.4, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("timing");
+        metric.Value.ShouldBe(42);
+    }
+
+    [Fact]
+    public static void Histogram_Conversion_Can_Be_Disabled()
+    {
+        // Arrange
+        var options = new StatsDMetricsOptions() { ConvertSecondsToMilliseconds = false };
+        using var listener = CreateListener(out var publisher, options);
+        using var meter = new Meter("TestMeter.HistogramsRaw");
+        var histogram = meter.CreateHistogram<double>("duration", unit: "s");
+
+        // Act
+        listener.InstrumentPublished(histogram, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().DoubleHandler!(histogram, 1.6, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("timing");
+        metric.Value.ShouldBe(2);
+    }
+
+    [Fact]
+    public static void Gauge_Measurements_Are_Published_As_Gauges()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.Gauges");
+        var gauge = meter.CreateGauge<double>("temperature");
+
+        // Act
+        listener.InstrumentPublished(gauge, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().DoubleHandler!(gauge, 21.5, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("gauge");
+        metric.Value.ShouldBe(21.5);
+    }
+
+    [Fact]
+    public static void ObservableGauge_Measurements_Are_Published_As_Gauges()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.ObservableGauges");
+        var gauge = meter.CreateObservableGauge("cpu", () => 0.5);
+
+        // Act
+        listener.InstrumentPublished(gauge, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().DoubleHandler!(gauge, 0.5, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("gauge");
+        metric.Value.ShouldBe(0.5);
+    }
+
+    [Fact]
+    public static void ObservableUpDownCounter_Measurements_Are_Published_As_Gauges()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.ObservableUpDown");
+        var counter = meter.CreateObservableUpDownCounter("queue.length", () => 8L);
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().LongHandler!(counter, 8, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("gauge");
+        metric.Value.ShouldBe(8);
+    }
+
+    [Fact]
+    public static void ObservableCounter_Measurements_Are_Published_As_Counter_Deltas()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.ObservableCounters");
+        var counter = meter.CreateObservableCounter("bytes", () => 0L);
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handler = listener.GetMeasurementHandlers().LongHandler!;
+
+        // Act and Assert - the first observation is published in full
+        handler(counter, 10, default, state);
+        publisher.Metrics.Count.ShouldBe(1);
+        publisher.Metrics.Last().Value.ShouldBe(10);
+        publisher.Metrics.Last().Kind.ShouldBe("counter");
+
+        // Subsequent observations publish the delta
+        handler(counter, 25, default, state);
+        publisher.Metrics.Count.ShouldBe(2);
+        publisher.Metrics.Last().Value.ShouldBe(15);
+
+        // An unchanged total publishes nothing
+        handler(counter, 25, default, state);
+        publisher.Metrics.Count.ShouldBe(2);
+
+        // A decreasing total is treated as a counter reset
+        handler(counter, 5, default, state);
+        publisher.Metrics.Count.ShouldBe(3);
+        publisher.Metrics.Last().Value.ShouldBe(5);
+    }
+
+    [Fact]
+    public static void ObservableCounter_Deltas_Are_Tracked_Per_Tag_Set()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.TaggedObservableCounters");
+        var counter = meter.CreateObservableCounter("bytes", () => 0L);
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handler = listener.GetMeasurementHandlers().LongHandler!;
+
+        var sent = new[] { new KeyValuePair<string, object?>("direction", "sent") };
+        var received = new[] { new KeyValuePair<string, object?>("direction", "received") };
+
+        // Act
+        handler(counter, 10, sent, state);
+        handler(counter, 100, received, state);
+        handler(counter, 15, sent, state);
+        handler(counter, 150, received, state);
+
+        // Assert
+        var metrics = publisher.Metrics.ToArray();
+        metrics.Length.ShouldBe(4);
+        metrics[0].Value.ShouldBe(10);
+        metrics[1].Value.ShouldBe(100);
+        metrics[2].Value.ShouldBe(5);
+        metrics[3].Value.ShouldBe(50);
+    }
+
+    [Fact]
+    public static void Fractional_Counter_Measurements_Accumulate_Instead_Of_Being_Lost()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.FractionalCounters");
+        var counter = meter.CreateCounter<double>("requests");
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handler = listener.GetMeasurementHandlers().DoubleHandler!;
+
+        // Act and Assert - each delta is below the rounding threshold, so nothing is published individually...
+        handler(counter, 0.4, default, state);
+        handler(counter, 0.4, default, state);
+        publisher.Metrics.ShouldBeEmpty();
+
+        // ...but the accumulated fractional parts are published once they exceed a whole unit.
+        handler(counter, 0.4, default, state);
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("counter");
+        metric.Value.ShouldBe(1);
+
+        // Over many measurements the published total matches the recorded total without drift.
+        handler(counter, 0.4, default, state);
+        handler(counter, 0.4, default, state);
+        publisher.Metrics.Sum((measurement) => measurement.Value).ShouldBe(2);
+    }
+
+    [Fact]
+    public static void Instrument_Tags_Are_Published_With_Measurement_Tags_Taking_Precedence()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.InstrumentTags");
+        var counter = meter.CreateCounter<int>(
+            "requests",
+            unit: null,
+            description: null,
+            tags: [new("host", "server1"), new("region", "eu")]);
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+
+        var tags = new[]
+        {
+            new KeyValuePair<string, object?>("status", 200),
+            new KeyValuePair<string, object?>("region", "us"),
+        };
+
+        // Act
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, tags, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Tags.ShouldNotBeNull();
+        metric.Tags.ShouldBe(new Dictionary<string, string?>()
+        {
+            ["host"] = "server1",
+            ["region"] = "us",
+            ["status"] = "200",
+        });
+    }
+
+    [Fact]
+    public static void Instrument_Tags_Are_Published_When_There_Are_No_Measurement_Tags()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.InstrumentOnlyTags");
+        var counter = meter.CreateCounter<int>(
+            "requests",
+            unit: null,
+            description: null,
+            tags: [new("host", "server1")]);
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Tags.ShouldNotBeNull();
+        metric.Tags.ShouldBe(new Dictionary<string, string?>() { ["host"] = "server1" });
+    }
+
+    [Fact]
+    public static void Tags_Are_Converted_To_Strings()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.Tags");
+        var counter = meter.CreateCounter<int>("requests");
+
+        var tags = new[]
+        {
+            new KeyValuePair<string, object?>("string", "value"),
+            new KeyValuePair<string, object?>("int", 200),
+            new KeyValuePair<string, object?>("bool", true),
+            new KeyValuePair<string, object?>("null", null),
+            new KeyValuePair<string, object?>("double", 1.5),
+        };
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, tags, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Tags.ShouldNotBeNull();
+        metric.Tags.ShouldBe(new Dictionary<string, string?>()
+        {
+            ["string"] = "value",
+            ["int"] = "200",
+            ["bool"] = "true",
+            ["null"] = null,
+            ["double"] = "1.5",
+        });
+    }
+
+    [Fact]
+    public static void Bucket_Names_Are_Sanitized()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("My Meter:v1");
+        var counter = meter.CreateCounter<int>("requests|total@host");
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Bucket.ShouldBe("My_Meter_v1.requests_total_host");
+    }
+
+    [Fact]
+    public static void Bucket_Names_Can_Be_Customized()
+    {
+        // Arrange
+        var options = new StatsDMetricsOptions()
+        {
+            BucketNameProvider = (instrument) => "custom." + instrument.Name,
+        };
+
+        using var listener = CreateListener(out var publisher, options);
+        using var meter = new Meter("TestMeter.CustomBuckets");
+        var counter = meter.CreateCounter<int>("requests");
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Bucket.ShouldBe("custom.requests");
+    }
+
+    [Fact]
+    public static void Sample_Rates_Can_Be_Customized()
+    {
+        // Arrange
+        var options = new StatsDMetricsOptions()
+        {
+            SampleRateProvider = (_) => 0.5,
+        };
+
+        using var listener = CreateListener(out var publisher, options);
+        using var meter = new Meter("TestMeter.SampleRates");
+        var counter = meter.CreateCounter<int>("requests");
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.SampleRate.ShouldBe(0.5);
+    }
+
+    [Fact]
+    public static void Unknown_Instrument_Types_Are_Not_Enabled()
+    {
+        // Arrange
+        using var listener = CreateListener(out _);
+        using var meter = new Meter("TestMeter.Unknown");
+        var instrument = new CustomInstrument(meter, "custom");
+
+        // Act and Assert
+        listener.InstrumentPublished(instrument, out object? state).ShouldBeFalse();
+        state.ShouldBeNull();
+    }
+
+    [Fact]
+    public static void All_Numeric_Measurement_Types_Are_Published()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.Numeric");
+        var counter = meter.CreateCounter<byte>("requests");
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handlers = listener.GetMeasurementHandlers();
+
+        // Act
+        handlers.ByteHandler!(counter, 1, default, state);
+        handlers.ShortHandler!(counter, 2, default, state);
+        handlers.IntHandler!(counter, 3, default, state);
+        handlers.LongHandler!(counter, 4, default, state);
+        handlers.FloatHandler!(counter, 5.4f, default, state);
+        handlers.DoubleHandler!(counter, 6.5, default, state);
+        handlers.DecimalHandler!(counter, 7.6m, default, state);
+
+        // Assert
+        publisher.Metrics.Select((metric) => metric.Value).ShouldBe([1, 2, 3, 4, 5, 7, 8]);
+    }
+
+    [Fact]
+    public static void Measurements_With_No_State_Are_Ignored()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.NoState");
+        var counter = meter.CreateCounter<int>("requests");
+
+        // Act
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, default, null);
+
+        // Assert
+        publisher.Metrics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public static void MeasurementsCompleted_Does_Not_Throw()
+    {
+        // Arrange
+        using var listener = CreateListener(out _);
+        using var meter = new Meter("TestMeter.Completed");
+        var counter = meter.CreateCounter<int>("requests");
+
+        // Act and Assert
+        listener.MeasurementsCompleted(counter, null);
+    }
+
+    [Fact]
+    public static void Dispose_Can_Be_Called_Multiple_Times()
+    {
+        // Arrange
+        var listener = CreateListener(out _);
+
+        // Act and Assert
+        listener.Dispose();
+        listener.Dispose();
+    }
+
+    private static StatsDMetricsListener CreateListener(out FakeStatsDPublisher publisher, StatsDMetricsOptions? options = null)
+    {
+        publisher = new FakeStatsDPublisher();
+        return new StatsDMetricsListener(publisher, Options.Create(options ?? new StatsDMetricsOptions()));
+    }
+
+    private sealed class CustomInstrument(Meter meter, string name) : Instrument<int>(meter, name, null, null);
+}

--- a/tests/JustEat.StatsD.Diagnostics.Tests/StatsDMetricsListenerTests.cs
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/StatsDMetricsListenerTests.cs
@@ -396,6 +396,167 @@ public static class StatsDMetricsListenerTests
     }
 
     [Fact]
+    public static void Custom_Bucket_Names_Are_Sanitized()
+    {
+        // Arrange
+        var options = new StatsDMetricsOptions()
+        {
+            BucketNameProvider = (instrument) => "custom bucket:" + instrument.Name + "|total@host",
+        };
+
+        using var listener = CreateListener(out var publisher, options);
+        using var meter = new Meter("TestMeter.CustomSanitizedBuckets");
+        var counter = meter.CreateCounter<int>("requests");
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Bucket.ShouldBe("custom_bucket_requests_total_host");
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    [InlineData(0)]
+    [InlineData(-0.5)]
+    [InlineData(1.5)]
+    public static void Invalid_Sample_Rates_Are_Ignored(double sampleRate)
+    {
+        // Arrange
+        var options = new StatsDMetricsOptions()
+        {
+            SampleRateProvider = (_) => sampleRate,
+        };
+
+        using var listener = CreateListener(out var publisher, options);
+        using var meter = new Meter("TestMeter.InvalidSampleRates");
+        var counter = meter.CreateCounter<int>("requests");
+
+        // Act
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().IntHandler!(counter, 1, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.SampleRate.ShouldBe(1);
+    }
+
+    [Fact]
+    public static void Counter_Residuals_Are_Tracked_Per_Tag_Set_Regardless_Of_Tag_Order()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.ReorderedCounterTags");
+        var counter = meter.CreateCounter<double>("requests");
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handler = listener.GetMeasurementHandlers().DoubleHandler!;
+
+        var tags = new[]
+        {
+            new KeyValuePair<string, object?>("host", "server1"),
+            new KeyValuePair<string, object?>("region", "eu"),
+        };
+
+        var reordered = new[] { tags[1], tags[0] };
+
+        // Act - the same tags recorded in a different order are the same time series
+        handler(counter, 0.5, tags, state);
+        handler(counter, 0.5, reordered, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Value.ShouldBe(1);
+    }
+
+    [Fact]
+    public static void ObservableCounter_Deltas_Are_Tracked_Per_Tag_Set_Regardless_Of_Tag_Order()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.ReorderedObservableCounterTags");
+        var counter = meter.CreateObservableCounter("bytes", () => 0L);
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handler = listener.GetMeasurementHandlers().LongHandler!;
+
+        var tags = new[]
+        {
+            new KeyValuePair<string, object?>("host", "server1"),
+            new KeyValuePair<string, object?>("region", "eu"),
+        };
+
+        var reordered = new[] { tags[1], tags[0] };
+
+        // Act
+        handler(counter, 10, tags, state);
+        handler(counter, 25, reordered, state);
+
+        // Assert - the second observation is a delta, not a new time series
+        var metrics = publisher.Metrics.ToArray();
+        metrics.Length.ShouldBe(2);
+        metrics[0].Value.ShouldBe(10);
+        metrics[1].Value.ShouldBe(15);
+    }
+
+    [Fact]
+    public static void Null_And_Empty_Tag_Values_Are_Tracked_Separately()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.NullAndEmptyTags");
+        var counter = meter.CreateObservableCounter("bytes", () => 0L);
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handler = listener.GetMeasurementHandlers().LongHandler!;
+
+        var nullValue = new[] { new KeyValuePair<string, object?>("region", null) };
+        var emptyValue = new[] { new KeyValuePair<string, object?>("region", string.Empty) };
+
+        // Act
+        handler(counter, 10, nullValue, state);
+        handler(counter, 20, emptyValue, state);
+
+        // Assert - the two tag sets are different time series, so both totals are published in full
+        var metrics = publisher.Metrics.ToArray();
+        metrics.Length.ShouldBe(2);
+        metrics[0].Value.ShouldBe(10);
+        metrics[1].Value.ShouldBe(20);
+    }
+
+    [Fact]
+    public static void Tag_Sets_Larger_Than_The_Stack_Allocation_Threshold_Are_Tracked_Correctly()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.ManyTags");
+        var counter = meter.CreateObservableCounter("bytes", () => 0L);
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handler = listener.GetMeasurementHandlers().LongHandler!;
+
+        var tags = Enumerable.Range(0, 20)
+            .Select((i) => new KeyValuePair<string, object?>($"tag{i:00}", i))
+            .ToArray();
+
+        var reordered = tags.Reverse().ToArray();
+
+        // Act
+        handler(counter, 10, tags, state);
+        handler(counter, 25, reordered, state);
+
+        // Assert
+        var metrics = publisher.Metrics.ToArray();
+        metrics.Length.ShouldBe(2);
+        metrics[0].Value.ShouldBe(10);
+        metrics[1].Value.ShouldBe(15);
+    }
+
+    [Fact]
     public static void Sample_Rates_Can_Be_Customized()
     {
         // Arrange

--- a/tests/JustEat.StatsD.Diagnostics.Tests/StatsDMetricsListenerTests.cs
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/StatsDMetricsListenerTests.cs
@@ -87,6 +87,24 @@ public static class StatsDMetricsListenerTests
     }
 
     [Fact]
+    public static void Integral_Histogram_Measurements_In_Seconds_Are_Published_As_Timers_In_Milliseconds()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.IntegralHistograms");
+        var histogram = meter.CreateHistogram<long>("duration", unit: "s");
+
+        // Act
+        listener.InstrumentPublished(histogram, out object? state).ShouldBeTrue();
+        listener.GetMeasurementHandlers().LongHandler!(histogram, 3, default, state);
+
+        // Assert
+        var metric = publisher.Metrics.ShouldHaveSingleItem();
+        metric.Kind.ShouldBe("timing");
+        metric.IntegralValue.ShouldBe(3000);
+    }
+
+    [Fact]
     public static void Histogram_Measurements_Not_In_Seconds_Are_Not_Converted()
     {
         // Arrange
@@ -236,6 +254,64 @@ public static class StatsDMetricsListenerTests
         metrics[1].Value.ShouldBe(100);
         metrics[2].Value.ShouldBe(5);
         metrics[3].Value.ShouldBe(50);
+    }
+
+    [Fact]
+    public static void ObservableCounter_Deltas_Are_Exact_For_Totals_Larger_Than_A_Double_Can_Represent()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.LargeObservableCounters");
+        var counter = meter.CreateObservableCounter("bytes", () => 0L);
+
+        listener.InstrumentPublished(counter, out object? state).ShouldBeTrue();
+        var handler = listener.GetMeasurementHandlers().LongHandler!;
+
+        // 2^53 is the largest integer for which every smaller integer is exactly
+        // representable as a double, so deltas either side of it would otherwise
+        // be quantized or lost entirely.
+        const long Threshold = 1L << 53;
+
+        // Act
+        handler(counter, Threshold, default, state);
+        handler(counter, Threshold + 1, default, state);
+        handler(counter, Threshold + 4, default, state);
+
+        // Assert
+        var metrics = publisher.Metrics.ToArray();
+        metrics.Length.ShouldBe(3);
+        metrics[0].IntegralValue.ShouldBe(Threshold);
+        metrics[1].IntegralValue.ShouldBe(1);
+        metrics[2].IntegralValue.ShouldBe(3);
+    }
+
+    [Fact]
+    public static void Integral_Measurements_Are_Published_Without_Loss_Of_Precision()
+    {
+        // Arrange
+        using var listener = CreateListener(out var publisher);
+        using var meter = new Meter("TestMeter.LargeIntegrals");
+        var counter = meter.CreateCounter<long>("bytes");
+        var histogram = meter.CreateHistogram<long>("size", unit: "By");
+
+        const long Value = long.MaxValue - 1;
+
+        // Act
+        listener.InstrumentPublished(counter, out object? counterState).ShouldBeTrue();
+        listener.InstrumentPublished(histogram, out object? histogramState).ShouldBeTrue();
+
+        var handler = listener.GetMeasurementHandlers().LongHandler!;
+
+        handler(counter, Value, default, counterState);
+        handler(histogram, Value, default, histogramState);
+
+        // Assert
+        var metrics = publisher.Metrics.ToArray();
+        metrics.Length.ShouldBe(2);
+        metrics[0].Kind.ShouldBe("counter");
+        metrics[0].IntegralValue.ShouldBe(Value);
+        metrics[1].Kind.ShouldBe("timing");
+        metrics[1].IntegralValue.ShouldBe(Value);
     }
 
     [Fact]

--- a/tests/JustEat.StatsD.Diagnostics.Tests/WhenRegisteringStatsDMetrics.cs
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/WhenRegisteringStatsDMetrics.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Options;
+
+namespace JustEat.StatsD.Diagnostics;
+
+public static class WhenRegisteringStatsDMetrics
+{
+    [Fact]
+    public static void Can_Register_The_StatsD_Listener()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IStatsDPublisherWithTags>(new FakeStatsDPublisher());
+
+        // Act
+        services.AddMetrics((metrics) => metrics.AddStatsD());
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var listener = provider.GetServices<IMetricsListener>().ShouldHaveSingleItem();
+        listener.ShouldBeOfType<StatsDMetricsListener>();
+    }
+
+    [Fact]
+    public static void Registering_The_Listener_Twice_Adds_One_Listener()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IStatsDPublisherWithTags>(new FakeStatsDPublisher());
+
+        // Act
+        services.AddMetrics((metrics) => metrics.AddStatsD().AddStatsD());
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var listener = provider.GetServices<IMetricsListener>().ShouldHaveSingleItem();
+        listener.ShouldBeOfType<StatsDMetricsListener>();
+    }
+
+    [Fact]
+    public static void Can_Configure_The_Options()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton<IStatsDPublisherWithTags>(new FakeStatsDPublisher());
+
+        // Act
+        services.AddMetrics((metrics) => metrics.AddStatsD((options) =>
+        {
+            options.ConvertSecondsToMilliseconds = false;
+            options.ObservableInstrumentsPollingInterval = TimeSpan.FromSeconds(1);
+        }));
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<StatsDMetricsOptions>>().Value;
+        options.ConvertSecondsToMilliseconds.ShouldBeFalse();
+        options.ObservableInstrumentsPollingInterval.ShouldBe(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public static void Options_Have_Expected_Defaults()
+    {
+        // Arrange
+        var options = new StatsDMetricsOptions();
+
+        // Assert
+        options.ObservableInstrumentsPollingInterval.ShouldBe(TimeSpan.FromSeconds(10));
+        options.ConvertSecondsToMilliseconds.ShouldBeTrue();
+        options.BucketNameProvider.ShouldBeNull();
+        options.SampleRateProvider.ShouldBeNull();
+    }
+
+    [Fact]
+    public static void AddStatsD_Validates_Arguments()
+    {
+        // Arrange
+        IMetricsBuilder builder = null!;
+
+        // Act and Assert
+        Should.Throw<ArgumentNullException>(() => builder.AddStatsD()).ParamName.ShouldBe("builder");
+    }
+}

--- a/tests/JustEat.StatsD.Diagnostics.Tests/WhenUsingTheMetricsHost.cs
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/WhenUsingTheMetricsHost.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Hosting;
+
+namespace JustEat.StatsD.Diagnostics;
+
+public static class WhenUsingTheMetricsHost
+{
+    [Fact]
+    public static async Task Measurements_Flow_To_StatsD_Through_The_Metrics_Pipeline()
+    {
+        // Arrange
+        var publisher = new FakeStatsDPublisher();
+
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton<IStatsDPublisherWithTags>(publisher);
+        builder.Services.AddMetrics((metrics) =>
+            metrics.AddStatsD((options) => options.ObservableInstrumentsPollingInterval = TimeSpan.FromMilliseconds(50))
+                   .EnableMetrics("HostMeter"));
+
+        using var host = builder.Build();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            var meterFactory = host.Services.GetRequiredService<IMeterFactory>();
+            using var meter = meterFactory.Create("HostMeter");
+
+            // Act - synchronous instruments are delivered as measurements are recorded
+            var counter = meter.CreateCounter<int>("requests");
+            counter.Add(3, new KeyValuePair<string, object?>("status", 200));
+
+            var histogram = meter.CreateHistogram<double>("request.duration", unit: "s");
+            histogram.Record(0.25);
+
+            // Assert
+            publisher.Metrics.ShouldContain((metric) => metric.Bucket == "HostMeter.requests");
+
+            var counterMetric = publisher.Metrics.First((metric) => metric.Bucket == "HostMeter.requests");
+            counterMetric.Kind.ShouldBe("counter");
+            counterMetric.Value.ShouldBe(3);
+            counterMetric.Tags.ShouldNotBeNull();
+            counterMetric.Tags.ShouldContainKeyAndValue("status", "200");
+
+            publisher.Metrics.ShouldContain((metric) => metric.Bucket == "HostMeter.request.duration");
+
+            var timingMetric = publisher.Metrics.First((metric) => metric.Bucket == "HostMeter.request.duration");
+            timingMetric.Kind.ShouldBe("timing");
+            timingMetric.Value.ShouldBe(250);
+
+            // Act - observable instruments are polled on a timer
+            long bytes = 0;
+            _ = meter.CreateObservableCounter("bytes", () => Interlocked.Add(ref bytes, 100));
+
+            // Assert
+            await WaitUntilAsync(() => publisher.Metrics.Any((metric) => metric.Bucket == "HostMeter.bytes"));
+
+            var observableMetric = publisher.Metrics.First((metric) => metric.Bucket == "HostMeter.bytes");
+            observableMetric.Kind.ShouldBe("counter");
+            observableMetric.Value.ShouldBe(100);
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public static async Task Measurements_Are_Not_Published_For_Meters_That_Are_Not_Enabled()
+    {
+        // Arrange
+        var publisher = new FakeStatsDPublisher();
+
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton<IStatsDPublisherWithTags>(publisher);
+        builder.Services.AddMetrics((metrics) => metrics.AddStatsD().EnableMetrics("HostMeter.Enabled"));
+
+        using var host = builder.Build();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            var meterFactory = host.Services.GetRequiredService<IMeterFactory>();
+            using var meter = meterFactory.Create("HostMeter.Disabled");
+
+            // Act
+            var counter = meter.CreateCounter<int>("requests");
+            counter.Add(1);
+
+            // Assert
+            publisher.Metrics.ShouldBeEmpty();
+        }
+        finally
+        {
+            await host.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        var timeout = TimeSpan.FromSeconds(30);
+        var delay = TimeSpan.FromMilliseconds(50);
+        var stopAt = DateTimeOffset.UtcNow.Add(timeout);
+
+        while (!condition() && DateTimeOffset.UtcNow < stopAt)
+        {
+            await Task.Delay(delay, TestContext.Current.CancellationToken);
+        }
+
+        condition().ShouldBeTrue("The condition was not satisfied within the timeout.");
+    }
+}

--- a/tests/JustEat.StatsD.Diagnostics.Tests/xunit.runner.json
+++ b/tests/JustEat.StatsD.Diagnostics.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "methodDisplay": "method"
+}


### PR DESCRIPTION
Adds a new `JustEat.StatsD.Diagnostics` package that implements an `IMetricsListener` to publish `System.Diagnostics.Metrics` measurements — including .NET's built-in metrics — to StatsD, mapping counters/up-down-counters to StatsD counters, histograms to timers (with optional seconds-to-milliseconds conversion), and gauges/observable instruments appropriately.

The listener supports configurable bucket naming and sample rates, polls observable instruments on a configurable interval, converts observable-counter totals to deltas, accumulates fractional deltas for floating-point counters so sub-unit measurements are not lost, and merges instrument-level tags with per-measurement tags. The change wires the new project and its tests into the solution, build script, per-project coverage output and package docs.